### PR TITLE
ci: fix npm release publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,16 @@ on:
     types: [published]
   workflow_dispatch:
     inputs:
+      publish_npm:
+        description: "Publish @snoai/llmix to npm"
+        required: false
+        default: true
+        type: boolean
+      publish_pypi:
+        description: "Publish llmix to PyPI"
+        required: false
+        default: false
+        type: boolean
       publish_rust:
         description: "Publish llmix-rs to crates.io"
         required: false
@@ -17,7 +27,7 @@ permissions:
 jobs:
   publish-npm:
     name: Publish npm
-    if: ${{ github.event.repository.private == false }}
+    if: ${{ github.event.repository.private == false && (github.event_name == 'release' || inputs.publish_npm == true) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -32,10 +42,8 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v6
         with:
-          node-version: "22"
-
-      - name: Install latest npm
-        run: npm install -g npm@latest
+          node-version: "24"
+          registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -62,11 +70,11 @@ jobs:
           NODE
 
       - name: Publish npm package
-        run: npm publish --access public --provenance
+        run: npm publish --access public
 
   publish-pypi:
     name: Publish PyPI
-    if: ${{ github.event.repository.private == false }}
+    if: ${{ github.event.repository.private == false && (github.event_name == 'release' || inputs.publish_pypi == true) }}
     runs-on: ubuntu-latest
     permissions:
       contents: read

--- a/bun.lock
+++ b/bun.lock
@@ -40,9 +40,6 @@
       ],
     },
   },
-  "overrides": {
-    "zod": "4.4.3",
-  },
   "packages": {
     "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.75", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-5AV3CKwaOJFdGXhihVgvRLNrjwRn2Xmy71YygT8DYOA+5zTx93Seg2QSIS8b3tJxzZ7X4H84pEtrE8VZKBCZGA=="],
 

--- a/package.json
+++ b/package.json
@@ -52,9 +52,6 @@
     "proper-lockfile": "^4.1.2",
     "zod": "^4.4.3"
   },
-  "overrides": {
-    "zod": "4.4.3"
-  },
   "peerDependencies": {
     "@ai-sdk/anthropic": ">=3.0.0",
     "@ai-sdk/google": ">=3.0.0",


### PR DESCRIPTION
## Summary
- make release workflow dispatch able to publish npm independently from PyPI/crates
- use the npm Trusted Publishing setup from current npm docs: Node 24, registry-url, OIDC permission, plain `npm publish`
- remove the direct `zod` override that makes npm fail with EOVERRIDE during `npm pack`/publish

## Verification
- bun run build
- bunx tsc -p tsconfig.check.json
- bun test
- npm pack --dry-run --json with release allowlist check