### PR TITLE
chore: prepare PyPI package metadata

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 name = "llmix"
 version = "2.0.0"
 description = "Cross-runtime LLM orchestration for Python, TypeScript, and Rust with L2 caching, retries, key rotation, and config-driven runtime control"
+readme = "README.md"
 requires-python = ">=3.14"
 dependencies = [
   "openai>=2.0.0",

--- a/uv.lock
+++ b/uv.lock
@@ -469,8 +469,8 @@ redis = [
 [package.metadata]
 requires-dist = [
     { name = "anthropic", specifier = ">=0.40.0" },
-    { name = "cachetools", specifier = ">=5.5.0,<6" },
-    { name = "google-genai", specifier = ">=1.18.0,<2" },
+    { name = "cachetools", specifier = ">=5.5.0,<8" },
+    { name = "google-genai", specifier = ">=1.18.0,<3" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1,<0.29" },
     { name = "json-repair", specifier = ">=0.58.0,<1" },
     { name = "openai", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary
- add README metadata for the PyPI package page
- sync uv.lock dependency metadata with pyproject.toml

## Verification
- uv build
- uvx twine check dist/*
- uv run pyright
- uv run --extra dev pytest
- install built wheel in a fresh Python 3.14 venv and import llmix