### PR TITLE
chore: rename PyPI package to sno-llmix

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -12,7 +12,7 @@ body:
     id: version
     attributes:
       label: LLMix version
-      description: e.g. `@snoai/llmix` 2.0.1, `llmix` 2.0.1, `llmix-rs` 2.0.0
+      description: e.g. `@snoai/llmix` 2.0.1, `sno-llmix` 2.0.1, `llmix-rs` 2.0.0
       placeholder: 2.0.1
     validations:
       required: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,7 +11,7 @@ on:
         default: true
         type: boolean
       publish_pypi:
-        description: "Publish llmix to PyPI"
+        description: "Publish sno-llmix to PyPI"
         required: false
         default: false
         type: boolean

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # LLMix
 
 [![npm version](https://img.shields.io/npm/v/@snoai/llmix.svg)](https://www.npmjs.com/package/@snoai/llmix)
-[![PyPI](https://img.shields.io/pypi/v/llmix.svg)](https://pypi.org/project/llmix/)
+[![PyPI](https://img.shields.io/pypi/v/sno-llmix.svg)](https://pypi.org/project/sno-llmix/)
 [![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
 [![TypeScript 5.0+](https://img.shields.io/badge/TypeScript-5.0%2B-blue.svg)](https://www.typescriptlang.org/)
 [![Rust 1.83+](https://img.shields.io/badge/rust-1.83%2B-orange.svg)](https://www.rust-lang.org/)
@@ -37,6 +37,10 @@ Provider, model, and parameters can live in a `.mda` preset. Edit the preset, pu
 ## Quick Start
 
 ### Python
+
+```bash
+pip install sno-llmix
+```
 
 ```python
 from llmix import (

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "llmix"
+name = "sno-llmix"
 version = "2.0.0"
 description = "Cross-runtime LLM orchestration for Python, TypeScript, and Rust with L2 caching, retries, key rotation, and config-driven runtime control"
 readme = "README.md"

--- a/uv.lock
+++ b/uv.lock
@@ -441,50 +441,6 @@ wheels = [
 ]
 
 [[package]]
-name = "llmix"
-version = "2.0.0"
-source = { editable = "." }
-dependencies = [
-    { name = "anthropic" },
-    { name = "cachetools" },
-    { name = "google-genai" },
-    { name = "httpx", extra = ["http2"] },
-    { name = "json-repair" },
-    { name = "openai" },
-    { name = "openrouter" },
-    { name = "pydantic" },
-    { name = "snoai-mda-config" },
-]
-
-[package.optional-dependencies]
-dev = [
-    { name = "pyright" },
-    { name = "pytest" },
-    { name = "pytest-asyncio" },
-]
-redis = [
-    { name = "redis" },
-]
-
-[package.metadata]
-requires-dist = [
-    { name = "anthropic", specifier = ">=0.40.0" },
-    { name = "cachetools", specifier = ">=5.5.0,<8" },
-    { name = "google-genai", specifier = ">=1.18.0,<3" },
-    { name = "httpx", extras = ["http2"], specifier = ">=0.28.1,<0.29" },
-    { name = "json-repair", specifier = ">=0.58.0,<1" },
-    { name = "openai", specifier = ">=2.0.0" },
-    { name = "openrouter", specifier = ">=0.9.1" },
-    { name = "pydantic", specifier = ">=2,<3" },
-    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
-    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
-    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
-    { name = "redis", marker = "extra == 'redis'", specifier = ">=6.4.0,<8" },
-    { name = "snoai-mda-config", specifier = ">=1.0.0,<2" },
-]
-provides-extras = ["redis", "dev"]
-
-[[package]]
 name = "nodeenv"
 version = "1.10.0"
 source = { registry = "https://pypi.org/simple" }
@@ -791,6 +747,50 @@ sdist = { url = "https://files.pythonhosted.org/packages/a2/87/a6771e1546d97e7e0
 wheels = [
     { url = "https://files.pythonhosted.org/packages/e9/44/75a9c9421471a6c4805dbf2356f7c181a29c1879239abab1ea2cc8f38b40/sniffio-1.3.1-py3-none-any.whl", hash = "sha256:2f6da418d1f1e0fddd844478f41680e794e6051915791a034ff65e5f100525a2", size = 10235, upload-time = "2024-02-25T23:20:01.196Z" },
 ]
+
+[[package]]
+name = "sno-llmix"
+version = "2.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "anthropic" },
+    { name = "cachetools" },
+    { name = "google-genai" },
+    { name = "httpx", extra = ["http2"] },
+    { name = "json-repair" },
+    { name = "openai" },
+    { name = "openrouter" },
+    { name = "pydantic" },
+    { name = "snoai-mda-config" },
+]
+
+[package.optional-dependencies]
+dev = [
+    { name = "pyright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+]
+redis = [
+    { name = "redis" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "anthropic", specifier = ">=0.40.0" },
+    { name = "cachetools", specifier = ">=5.5.0,<8" },
+    { name = "google-genai", specifier = ">=1.18.0,<3" },
+    { name = "httpx", extras = ["http2"], specifier = ">=0.28.1,<0.29" },
+    { name = "json-repair", specifier = ">=0.58.0,<1" },
+    { name = "openai", specifier = ">=2.0.0" },
+    { name = "openrouter", specifier = ">=0.9.1" },
+    { name = "pydantic", specifier = ">=2,<3" },
+    { name = "pyright", marker = "extra == 'dev'", specifier = ">=1.1.0" },
+    { name = "pytest", marker = "extra == 'dev'", specifier = ">=8.0.0" },
+    { name = "pytest-asyncio", marker = "extra == 'dev'", specifier = ">=0.24" },
+    { name = "redis", marker = "extra == 'redis'", specifier = ">=6.4.0,<8" },
+    { name = "snoai-mda-config", specifier = ">=1.0.0,<2" },
+]
+provides-extras = ["redis", "dev"]
 
 [[package]]
 name = "snoai-mda-config"


### PR DESCRIPTION
## Summary
- rename the Python distribution from `llmix` to `sno-llmix`
- keep the Python import package as `llmix`
- update README badge/install command and public issue/workflow text

## Verification
- `uv lock`
- `uv build`
- `uvx twine check dist/*`
- `uv run pyright`
- `uv run --extra dev pytest`
- installed built wheel in a fresh Python 3.14 venv and verified `import llmix` plus `importlib.metadata.version("sno-llmix")`