### PR TITLE
ci: use crates trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -101,6 +101,9 @@ jobs:
     name: Publish crates.io
     if: ${{ github.event.repository.private == false && github.event_name == 'workflow_dispatch' && inputs.publish_rust }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -108,8 +111,12 @@ jobs:
       - name: Setup Rust
         uses: dtolnay/rust-toolchain@1.100
 
+      - name: Authenticate with crates.io
+        id: auth
+        uses: rust-lang/crates-io-auth-action@v1
+
       - name: Publish crate
         working-directory: rust/llmix-rs
         env:
-          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ steps.auth.outputs.token }}
         run: cargo publish

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # LLMix
 
-[![npm version](https://img.shields.io/npm/v/@snoai/llmix.svg)](https://www.npmjs.com/package/@snoai/llmix)
-[![PyPI](https://img.shields.io/pypi/v/sno-llmix.svg)](https://pypi.org/project/sno-llmix/)
-[![crates.io](https://img.shields.io/crates/v/llmix-rs.svg)](https://crates.io/crates/llmix-rs)
-[![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-blue.svg)](https://www.python.org/downloads/)
-[![TypeScript 5.0+](https://img.shields.io/badge/TypeScript-5.0%2B-blue.svg)](https://www.typescriptlang.org/)
-[![Rust 1.83+](https://img.shields.io/badge/rust-1.83%2B-orange.svg)](https://www.rust-lang.org/)
-[![License: Apache--2.0](https://img.shields.io/badge/License-Apache--2.0-green.svg)](LICENSE)
+[![npm version](https://img.shields.io/npm/v/@snoai/llmix.svg?label=npm&labelColor=3b3b3b&color=cb3837)](https://www.npmjs.com/package/@snoai/llmix)
+[![PyPI](https://img.shields.io/pypi/v/sno-llmix.svg?label=pypi&labelColor=3b3b3b&color=3775a9)](https://pypi.org/project/sno-llmix/)
+[![crates.io](https://img.shields.io/crates/v/llmix-rs.svg?label=crates.io&labelColor=3b3b3b&color=d67b2b)](https://crates.io/crates/llmix-rs)
+[![Python 3.14+](https://img.shields.io/badge/python-3.14%2B-ffd43b.svg?labelColor=306998)](https://www.python.org/downloads/)
+[![TypeScript 5.0+](https://img.shields.io/badge/TypeScript-5.0%2B-3178c6.svg?labelColor=3b3b3b)](https://www.typescriptlang.org/)
+[![Rust 1.83+](https://img.shields.io/badge/rust-1.83%2B-b7410e.svg?labelColor=3b3b3b)](https://www.rust-lang.org/)
+[![License: Apache--2.0](https://img.shields.io/badge/License-Apache--2.0-97ca00.svg?labelColor=3b3b3b)](LICENSE)
 
 > **Config-driven harness around your LLM SDK.**
 > Swap models by editing MDA presets. Keep the SDK you already use.


### PR DESCRIPTION
## Summary
- switch crates.io release job from long-lived secret to crates.io trusted publishing
- add OIDC permission and rust-lang/crates-io-auth-action token exchange
- tune README badge colors now that npm, PyPI, and crates.io are all published

## Verification
- git diff --check
- cargo info llmix-rs

## Manual follow-up
Configure crates.io Trusted Publishing for llmix-rs with owner sno-ai, repo llmix, workflow release.yml, environment left blank.