### PR TITLE
chore: update .gitignore and README for MDA config documentation and local workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,4 +26,6 @@ __pycache__/
 # Rust
 packages/llmix/rust/target/
 packages/mda-config/rust/target/
-.claude/scheduled_tasks.lock
+.claude/*
+.codex/*
+openspec/*

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,11 @@ __pycache__/
 # Session
 .remember/*
 
+# Local release/dev workflow
+VERSION.YAML
+VERSION.yaml
+internal/dev-scripts/
+
 # Pytest
 .pytest_cache/
 .ruff_cache/

--- a/README.md
+++ b/README.md
@@ -58,11 +58,9 @@ pip install "sno-llmix[redis]"
 cargo add llmix-rs --features providers-openai,redis
 ```
 
-LLMix also carries the MDA config foundation packages in this monorepo. They keep
-their original package names: `@snoai/mda-config` for TypeScript and
-`snoai-mda-config` for Python and Rust. Use them when you need to validate,
-compose, load, or enforce trust policy for `.mda` configuration files outside
-the LLMix runtime.
+LLMix uses the MDA config packages for preset loading. They are also published
+as standalone runtime loaders for apps that need `.mda` validation, integrity,
+or trust-policy enforcement outside LLMix.
 
 ---
 
@@ -74,7 +72,7 @@ the LLMix runtime.
 - [Rust guide](docs/llmix/llmix-rust.md)
 - [Secure LLMix configuration](docs/llmix/secure-llmix-configuration.md)
 - [Key pool operations](docs/llmix/key-pool-operations.md)
-- [MDA config quick start](docs/mda-config/cli-and-runtime-quick-start.md)
+- [Standalone MDA config loader docs](docs/mda-config/README.md)
 
 ---
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "packages/llmix/typescript": {
       "name": "@snoai/llmix",
-      "version": "2.0.0",
+      "version": "2.0.1",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.10",
         "@openrouter/sdk": "^0.12.21",

--- a/docs/mda-config/README.md
+++ b/docs/mda-config/README.md
@@ -6,7 +6,7 @@ The MDA CLI and these packages do different jobs. Use
 [`@markdown-ai/cli`](https://github.com/sno-ai/mda-markdown) while authoring:
 create a file, validate it, compute or verify integrity, and compile it into
 agent-facing Markdown when you need `SKILL.md`, `AGENTS.md`, or
-`CLAUDE.md`.
+`CLAUDE.md`, or `MCP-SERVER.md`.
 
 Use `mda-config` at runtime: load an already-authored `.mda` source file,
 validate the frontmatter against your product schema, optionally enforce

--- a/packages/llmix/python/pyproject.toml
+++ b/packages/llmix/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sno-llmix"
-version = "2.0.0"
+version = "2.0.1"
 description = "Cross-runtime LLM orchestration for Python, TypeScript, and Rust with L2 caching, retries, key rotation, and config-driven runtime control"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/llmix/rust/Cargo.lock
+++ b/packages/llmix/rust/Cargo.lock
@@ -42,9 +42,9 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "aws-lc-rs"
-version = "1.16.2"
+version = "1.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a054912289d18629dc78375ba2c3726a3afe3ff71b4edba9dedfca0e3446d1fc"
+checksum = "0ec6fb3fe69024a75fa7e1bfb48aa6cf59706a101658ea01bfd33b2b248a038f"
 dependencies = [
  "aws-lc-sys",
  "zeroize",
@@ -52,9 +52,9 @@ dependencies = [
 
 [[package]]
 name = "aws-lc-sys"
-version = "0.39.1"
+version = "0.40.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83a25cf98105baa966497416dbd42565ce3a8cf8dbfd59803ec9ad46f3126399"
+checksum = "f50037ee5e1e41e7b8f9d161680a725bd1626cb6f8c7e901f91f942850852fe7"
 dependencies = [
  "cc",
  "cmake",
@@ -70,9 +70,9 @@ checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bitflags"
-version = "2.11.0"
+version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
 name = "block-buffer"
@@ -97,9 +97,9 @@ checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
 
 [[package]]
 name = "cc"
-version = "1.2.60"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43c5703da9466b66a946814e1adf53ea2c90f10063b86290cc9eb67ce3478a20"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -481,9 +481,9 @@ dependencies = [
 
 [[package]]
 name = "js-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2964e92d1d9dc3364cae4d718d93f227e3abb088e747d92e0395bfdedf1c12ca"
+checksum = "67df7112613f8bfd9150013a0314e196f4800d3201ae742489d999db2f979f08"
 dependencies = [
  "cfg-if",
  "futures-util",
@@ -493,13 +493,13 @@ dependencies = [
 
 [[package]]
 name = "libc"
-version = "0.2.184"
+version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
+checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "llmix-rs"
-version = "2.0.0"
+version = "2.0.1"
 dependencies = [
  "async-trait",
  "fs2",
@@ -698,9 +698,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "rand"
-version = "0.9.3"
+version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ec095654a25171c2124e9e3393a930bddbffdc939556c914957a4c3e0a87166"
+checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
  "rand_chacha",
  "rand_core",
@@ -835,9 +835,9 @@ checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
 name = "rustls"
-version = "0.23.38"
+version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69f9466fb2c14ea04357e91413efb882e2a6d4a406e625449bc0a5d360d53a21"
+checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
  "aws-lc-rs",
  "log",
@@ -863,9 +863,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-pki-types"
-version = "1.14.0"
+version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
  "web-time",
  "zeroize",
@@ -873,9 +873,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-webpki"
-version = "0.103.11"
+version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20a6af516fea4b20eccceaf166e8aa666ac996208e8a644ce3ef5aa783bc7cd4"
+checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
  "aws-lc-rs",
  "ring",
@@ -1230,9 +1230,9 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
 
 [[package]]
 name = "unicode-bidi"
@@ -1301,18 +1301,18 @@ checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
 name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
  "wit-bindgen",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0bf938a0bacb0469e83c1e148908bd7d5a6010354cf4fb73279b7447422e3a89"
+checksum = "49ace1d07c165b0864824eee619580c4689389afa9dc9ed3a4c75040d82e6790"
 dependencies = [
  "cfg-if",
  "once_cell",
@@ -1323,9 +1323,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.68"
+version = "0.4.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f371d383f2fb139252e0bfac3b81b265689bf45b6874af544ffa4c975ac1ebf8"
+checksum = "96492d0d3ffba25305a7dc88720d250b1401d7edca02cc3bcd50633b424673b8"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1333,9 +1333,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eeff24f84126c0ec2db7a449f0c2ec963c6a49efe0698c4242929da037ca28ed"
+checksum = "8e68e6f4afd367a562002c05637acb8578ff2dea1943df76afb9e83d177c8578"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -1343,9 +1343,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d08065faf983b2b80a79fd87d8254c409281cf7de75fc4b773019824196c904"
+checksum = "d95a9ec35c64b2a7cb35d3fead40c4238d0940c86d107136999567a4703259f2"
 dependencies = [
  "bumpalo",
  "proc-macro2",
@@ -1356,18 +1356,18 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.118"
+version = "0.2.121"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5fd04d9e306f1907bd13c6361b5c6bfc7b3b3c095ed3f8a9246390f8dbdee129"
+checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.95"
+version = "0.3.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f2dfbb17949fa2088e5d39408c48368947b86f7834484e87b73de55bc14d97d"
+checksum = "4b572dff8bcf38bad0fa19729c89bb5748b2b9b1d8be70cf90df697e3a8f32aa"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -1385,9 +1385,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -1578,9 +1578,9 @@ checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
 
 [[package]]
 name = "wit-bindgen"
-version = "0.51.0"
+version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "zerocopy"

--- a/packages/llmix/rust/Cargo.toml
+++ b/packages/llmix/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llmix-rs"
-version = "2.0.0"
+version = "2.0.1"
 edition = "2021"
 rust-version = "1.83"
 license = "Apache-2.0"

--- a/packages/llmix/typescript/package.json
+++ b/packages/llmix/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snoai/llmix",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Config-driven harness around your LLM SDK. MDA-driven model swap, two-tier cache, circuit breaker, key-pool rotation.",
   "author": "Sno AI",
   "license": "Apache-2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "sno-llmix"
-version = "2.0.0"
+version = "2.0.1"
 source = { editable = "packages/llmix/python" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Merge `dev` branch into `main`.

## Version

Family: `llmix`
Version: `2.0.1`

## Commits (3)
```
c733e14 chore: bump llmix version to 2.0.1
56ae0b4 chore: update .gitignore and README for MDA config documentation and local workflow
7d8def4 chore: update .gitignore to include additional directories for Claude and Codex
```

## Changed Files
```
.gitignore
README.md
docs/mda-config/README.md
packages/llmix/python/pyproject.toml
packages/llmix/rust/Cargo.lock
packages/llmix/rust/Cargo.toml
packages/llmix/typescript/package.json
uv.lock
```

---
Created: 2026-05-10 06:03:09 UTC
By: Larry Hope
Head Commit: c733e14
