### PR TITLE
docs: update secure LLMix configuration documentation with detailed production registry trust flow and MDA CLI usage

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "packages/llmix/typescript": {
       "name": "@snoai/llmix",
-      "version": "2.0.3",
+      "version": "2.0.4",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.10",
         "@openrouter/sdk": "^0.12.21",

--- a/bun.lock
+++ b/bun.lock
@@ -10,7 +10,7 @@
     },
     "packages/llmix/typescript": {
       "name": "@snoai/llmix",
-      "version": "2.0.2",
+      "version": "2.0.3",
       "dependencies": {
         "@ai-sdk/provider": "^3.0.10",
         "@openrouter/sdk": "^0.12.21",

--- a/docs/llmix/secure-llmix-configuration.md
+++ b/docs/llmix/secure-llmix-configuration.md
@@ -7,10 +7,153 @@ approved?
 Short version:
 
 1. Put LLMix model settings in `.mda` files.
-2. Check or sign those files during release.
-3. Publish the LLMix registry.
-4. In production, load the published registry instead of reading editable `.mda`
-   files on every request.
+2. Sign those `.mda` files during release.
+3. Publish a signed LLMix registry root from verified `.mda` files.
+4. Store the runtime trust anchors outside `config/llm/`.
+5. In production, open the published registry with signed-root verification.
+
+The registry is the thing being checked. It cannot be the thing that proves
+itself. The trust anchor has to come from somewhere else.
+
+## Quick Start: Production Registry Trust
+
+Use this path when a production service must only run model settings your team
+approved.
+
+1. Create or update the `.mda` presets in a staging directory.
+2. Validate the presets and attach integrity.
+3. Sign the presets with your release identity.
+4. Publish the LLMix registry from those signed presets with
+   `trustedRuntime: true`.
+5. Sign the registry root produced by the publisher.
+6. Write the root digest, registry-root trust policy, and freshness policy to
+   deployment config.
+7. Start the app with those outside trust anchors.
+
+This is the same flow whether a human runs the release or an AI agent runs it
+for them. The agent should use machine-readable command output, stop on the
+first failed gate, and write into staging paths until the release artifacts are
+ready.
+
+The deployment should look like two separate inputs:
+
+```text
+app image or package
+  config/llm/
+    snapshots/
+      2026-05-09T120000Z/
+        resolved/
+        manifest.json
+        registry-root.json
+    current.json
+
+deployment config, secret manager, or release metadata
+  llmix.registryRootTrustPolicy
+  llmix.expectedRootDigest
+  llmix.rekorPolicy
+  llmix.highWatermark
+```
+
+`registry-root.json` is not the anchor. It is the signed evidence. If someone
+can replace the whole registry directory, they can replace that file too.
+
+The anchor is the outside value that does not move with the registry bundle:
+
+- a pinned `expectedRootDigest`;
+- a trust policy that pins the signer identity;
+- public keys, KMS/HSM identity, did:web verifier config, or Sigstore policy;
+- Rekor transparency log policy for Sigstore signatures;
+- high-watermark state used to reject rollback.
+
+For static app releases, pinning `expectedRootDigest` is the clearest boundary.
+Every meaningful registry change produces a different root digest. If the
+deployed files are swapped, runtime rejects them because the outside digest does
+not match.
+
+For continuously updated services, use signer policy plus freshness checks:
+`minimumRevision`, `minimumPublishedAt`, or an external high-watermark. That
+keeps an old but validly signed registry from coming back later like a bad cache
+entry.
+
+TypeScript runtime code should open the registry with anchors supplied by the
+application or deployment system:
+
+```typescript
+import { ConfigRegistryManager } from "@snoai/llmix";
+
+const manager = await ConfigRegistryManager.open("config/llm", {
+  signedRoot: {
+    trustPolicy: registryRootTrustPolicy,
+    rekorClient,
+    sigstoreVerifier,
+    didWebVerifier,
+    expectedRootDigest,
+    highWatermark,
+  },
+});
+```
+
+The important part is not the exact storage system. A file under `/etc`, a
+Kubernetes config, a mobile app binary, a signed release manifest, or a secret
+manager can all work. The important part is that it is not stored under the
+registry directory it is supposed to verify.
+
+### What the MDA CLI Can Do
+
+The MDA CLI should feel like the normal way to prepare MDA artifacts. A person
+or agent should be able to use one tool for the authoring loop:
+
+1. scaffold or update `.mda` files;
+2. validate source files;
+3. canonicalize content when a reproducible payload is needed;
+4. attach or verify integrity;
+5. compile generated Markdown targets when the artifact is for an agent runtime;
+6. sign with an explicit release identity;
+7. verify signatures against an explicit trust policy;
+8. emit machine-readable release metadata.
+
+That last output matters for LLMix. The registry bundle and the deployment trust
+manifest are two different artifacts.
+
+```text
+release output
+  config/llm/
+    snapshots/
+    current.json
+
+deployment trust manifest
+  expectedRootDigest
+  registryRootTrustPolicy
+  rekorPolicy
+  minimumRevision
+  minimumPublishedAt
+  highWatermark
+```
+
+The CLI can produce or help produce the manifest. It still should not become the
+production authority by itself. If a tool writes a trust policy into the same
+`config/llm/` directory, an attacker who can replace the registry can replace
+that policy too. That is just moving the lock onto the same door.
+
+For LLMix, the comfortable release path is:
+
+1. `mda validate` every source preset.
+2. `mda integrity verify` or attach integrity.
+3. `mda sign` each preset with the release identity.
+4. `mda verify` the signed presets against the release policy.
+5. Publish the LLMix registry with `trustedRuntime: true`.
+6. Sign the registry root.
+7. Emit `expectedRootDigest`, signer identity, and freshness metadata.
+8. Write that manifest to the external deployment channel.
+
+Today, the MDA CLI already has the right authoring shape: explicit targets,
+machine-readable JSON, validation, compile, canonicalization, integrity checks,
+and conformance checks. Full signing, full cryptographic verification, and the
+LLMix deployment trust manifest are the pieces this workflow asks the tooling to
+finish.
+
+After release, production only needs the runtime package, the registry bundle,
+and the external anchors. The CLI does not have to run while serving requests.
 
 ## Q&A
 
@@ -71,6 +214,7 @@ Current runtime support is language-specific:
 For production, the clean pattern is: verify signed `.mda` during release,
 publish a signed registry root, ship the registry with the app, keep deployed
 files read-only, and supply trust anchors from outside the registry bundle.
+The Quick Start above is the normal deployment shape.
 
 ### What should production code do?
 
@@ -265,27 +409,14 @@ create or verify signed MDA files.
 
 ## Recommended Release Flow
 
-For production services, use a plain release flow:
+For production services, keep authoring, release, and runtime separate.
 
-1. Put each model choice in a real `.mda` file, such as
-   `authoring/search_summary/openai_fast.mda`.
-2. Sign those `.mda` files with the MDA signing workflow your team already uses.
-   This is the step that says "this model config is approved."
-3. In CI or during release, publish the LLMix registry with verification checks
-   turned on. The trust policy says which signer you trust. If a preset is
-   unsigned or signed by the wrong identity, the publish step fails.
-4. Ship the generated `snapshots/` directory and `current.json` with your app,
-   package, or container image.
-5. In production, read only the published registry with
-   `ConfigRegistryManager`. Do not load editable `.mda` files during request
-   handling.
+Authoring is where people edit `.mda` files. CI is where those files become an
+approved registry. Runtime is where the app reads the approved registry and says
+yes or no. Keep those jobs separate and the whole system is much easier to
+reason about.
 
-This gives application teams a simple deployment model: no signing service is
-needed while handling user requests, and no cloud call is needed before every
-model request. The production service reads the files that were already
-published with the app.
-
-The layout should look like this:
+The registry layout should look like this:
 
 ```text
 config/llm/
@@ -305,6 +436,10 @@ config/llm/
 The trust policy, public keys, expected root digest, and high-watermark state
 are supplied by application or deployment configuration at runtime. They are not
 stored under `config/llm/` as the authority for the same registry bundle.
+
+During release, publish from trusted `.mda` sources. If a preset is unsigned,
+has bad integrity, or is signed by the wrong identity, publishing fails before
+the registry can reach production.
 
 TypeScript can require MDA integrity and signatures while publishing the
 registry files. For signed presets, use `trustedRuntime: true` with a trust

--- a/docs/mda-sign-flow/README.md
+++ b/docs/mda-sign-flow/README.md
@@ -1,0 +1,177 @@
+# MDA Signing Flow for LLMix
+
+This document describes the flow we want users and AI agents to have.
+
+It is not a low-level PRD. It is the path that should feel normal. A person has
+LLMix model settings in `.mda` files. An agent helps prepare them. CI signs and
+publishes them. Runtime only accepts the result when the outside trust anchor
+says yes.
+
+The registry cannot prove itself. That is the whole point.
+
+## Status Legend
+
+- Green: already in good shape.
+- Yellow: the direction is clear, but tooling still needs work.
+- Red: missing or unsafe if users must do it by hand.
+
+## The Happy Path
+
+| Step | Status | User expectation | What the CLI should help with | Current shape |
+| --- | --- | --- | --- | --- |
+| 1. Write `.mda` presets | Green | A human or AI agent creates and edits presets in a staging directory. | Scaffold files, keep target names explicit, return JSON for agents. | `mda init` and the basic authoring flow exist. |
+| 2. Validate the presets | Green | The tool catches bad frontmatter, wrong namespace shape, and target mistakes before release. | `mda validate --target source --json`. | Already good. |
+| 3. Add stable integrity | Green | The files get a reproducible fingerprint, so later edits are visible. | Canonicalize, compute integrity, verify integrity. | Already good. |
+| 4. Sign each `.mda` | Yellow | The release identity signs the approved presets. | Full `mda sign` for GitHub OIDC/Sigstore, KMS/HSM, and did:web where supported. | Flow is clear. Full signing still needs work. |
+| 5. Verify signed `.mda` | Yellow | CI checks that every preset was signed by a trusted identity. | Full cryptographic `mda verify` against an explicit trust policy. | Runtime hooks exist. CLI verification is not complete yet. |
+| 6. Publish the LLMix registry | Green | Verified presets become a registry bundle under `config/llm/`. | Let LLMix publish with `trustedRuntime: true`. | TypeScript is in good shape. Python and Rust should follow the same model. |
+| 7. Sign the registry root | Green | The whole registry snapshot gets one signed root. | Sign the registry root after publish. | TypeScript has signed registry-root support. |
+| 8. Choose and emit outside anchors | Yellow | The release produces a deployment trust manifest outside the registry bundle. | Emit digest, signer policy, Rekor policy, freshness policy, and deployment snippets. | The model is clear. CLI/release tooling should finish it. |
+| 9. Open registry at runtime | Green | The app starts only when the outside anchor accepts the registry. | Load anchors from app code, deployment config, or release metadata. | TypeScript supports this model. |
+
+## Anchor Choices
+
+Most users should not have to invent this part. The tool should ask for a
+profile, then emit the right files or snippets.
+
+### A. Pin `expectedRootDigest` in the app
+
+This is the simplest anchor.
+
+The release produces one digest for the signed registry root. The application
+stores that digest in code, a bundled config file, or the app binary. At startup,
+LLMix checks the deployed registry against that digest.
+
+Use this when the app and registry ship together.
+
+Tradeoff: every registry change requires an app release. That is not a bug. It
+is the boundary.
+
+CLI should help by emitting:
+
+- `expectedRootDigest`
+- a TypeScript/Python/Rust config snippet
+- a machine-readable JSON result for agents
+
+### B. Pin `expectedRootDigest` in deployment config
+
+This is still simple, but more flexible.
+
+The digest lives in `/etc/llmix/trust.json`, Kubernetes config, Terraform
+variables, GitHub Actions deployment outputs, a secret manager, or another
+deployment channel. It does not need to be secret. It needs to be outside
+`config/llm/`.
+
+Use this when the service and registry may deploy separately.
+
+CLI should help by emitting common formats:
+
+- JSON trust manifest
+- environment variables
+- Kubernetes ConfigMap or Secret snippet
+- GitHub Actions output
+- Terraform variable snippet
+
+### C. GitHub Actions OIDC + Sigstore/Rekor
+
+This should be the default for many teams.
+
+Do not trust "whatever file is in the GitHub repo." Trust the release identity:
+the repository, ref or environment, workflow identity, Sigstore signature, and
+Rekor transparency entry.
+
+This is close to the npm provenance model. The useful claim is not "someone
+uploaded this." The useful claim is "this came from this release workflow."
+
+Use this when a project already releases through GitHub Actions.
+
+CLI should help by emitting:
+
+- a GitHub Actions signing workflow snippet
+- a Sigstore/Rekor trust policy pinned to repo, ref, environment, and workflow
+- the signed `.mda` verification result
+- the signed registry-root verification result
+- a deployment trust manifest
+
+This profile can replace most hand-written signer policy work. It does not
+remove the need for an outside anchor. The anchor becomes the pinned policy and
+freshness state, and optionally an `expectedRootDigest` for static releases.
+
+### D. KMS/HSM or did:web
+
+This is for teams with stronger internal signing rules.
+
+Use it when a company already has cloud KMS, HSM, domain-controlled identity, or
+multi-signer release policy. It is stronger in the right environment, but it is
+not the easiest default.
+
+CLI should help by generating policy templates and checking that emitted
+signatures round-trip through verification.
+
+## Recommended Defaults
+
+For a small project:
+
+1. Use GitHub Actions OIDC + Sigstore/Rekor.
+2. Also emit `expectedRootDigest`.
+3. Store that digest in app config or deployment config.
+
+For a packaged app:
+
+1. Pin `expectedRootDigest` in the app.
+2. Ship the registry read-only with the app.
+
+For a service:
+
+1. Use GitHub Actions OIDC + Sigstore/Rekor.
+2. Store the deployment trust manifest outside `config/llm/`.
+3. Use freshness checks to reject rollback.
+
+## Deployment Trust Manifest
+
+The release should produce two outputs.
+
+```text
+registry bundle
+  config/llm/
+    snapshots/
+    current.json
+
+deployment trust manifest
+  expectedRootDigest
+  registryRootTrustPolicy
+  rekorPolicy
+  minimumRevision
+  minimumPublishedAt
+  highWatermark
+```
+
+The first output can ship with the application.
+
+The second output must come from somewhere else at runtime. App code, deployment
+config, secret manager, GitHub release metadata, KMS-backed config, Kubernetes,
+and Terraform can all work. The important part is not secrecy. The important
+part is separation.
+
+## What CLI Work This Implies
+
+The current CLI already has the right authoring shape: explicit targets,
+machine-readable JSON, validation, compile, canonicalization, integrity checks,
+and conformance checks.
+
+The flow above asks for these next pieces:
+
+1. Complete `mda sign`.
+2. Complete cryptographic `mda verify`.
+3. Add a GitHub Actions OIDC + Sigstore/Rekor profile.
+4. Generate trust policy templates for GitHub, KMS/HSM, and did:web.
+5. Emit deployment trust manifests.
+6. Emit deployment snippets for common systems.
+7. Keep every command agent-friendly with `--json`, stable diagnostics, and
+   non-zero exits when trust cannot be proven.
+
+The CLI can automate the release work. It should not become the runtime trust
+anchor by hiding the policy inside the same registry bundle.
+
+That would make the whole thing look secure while moving the lock onto the same
+door.

--- a/docs/mda-sign-flow/README.zh.md
+++ b/docs/mda-sign-flow/README.zh.md
@@ -1,0 +1,170 @@
+# LLMix 的 MDA 签名流程
+
+这份文件写的是我们希望使用者和 AI agent 怎么用。
+
+它不是底层技术 PRD。它是一个正常人会期待的顺序。人把 LLMix model
+settings 写在 `.mda`。AI agent 帮他整理。CI 签名和发布。runtime 只在外部
+trust anchor 说可以的时候才接受。
+
+registry 不能自己证明自己。这是整个设计的重点。
+
+## 状态标记
+
+- 绿色：已经做得不错。
+- 黄色：方向清楚，但工具还要补。
+- 红色：缺失，或者如果让使用者手动做会很容易出错。
+
+## 最顺的流程
+
+| 步骤 | 状态 | 使用者期待 | CLI 应该帮什么 | 目前状况 |
+| --- | --- | --- | --- | --- |
+| 1. 写 `.mda` presets | 绿色 | 人或 AI agent 在 staging 目录里创建和修改 presets。 | scaffold 文件，明确 target，给 agent 稳定 JSON。 | `mda init` 和基本 authoring flow 已经有。 |
+| 2. 检查 presets | 绿色 | release 前先抓出 frontmatter、namespace、target 的错误。 | `mda validate --target source --json`。 | 已经不错。 |
+| 3. 生成稳定 integrity | 绿色 | 文件有可重复的指纹，之后被改过就看得出来。 | canonicalize、compute integrity、verify integrity。 | 已经不错。 |
+| 4. 签每个 `.mda` | 黄色 | release identity 签过这些被批准的 presets。 | 完整 `mda sign`，支持 GitHub OIDC/Sigstore、KMS/HSM、did:web。 | 流程清楚，但完整 signing 还要补。 |
+| 5. 验证 signed `.mda` | 黄色 | CI 确认每个 preset 都是可信身份签的。 | 完整 cryptographic `mda verify`，用明确的 trust policy。 | runtime hooks 有方向，CLI verify 还没完整。 |
+| 6. 发布 LLMix registry | 绿色 | 验证过的 presets 变成 `config/llm/` registry bundle。 | LLMix publish 时启用 `trustedRuntime: true`。 | TypeScript 已经不错。Python 和 Rust 应该照这个模型补齐。 |
+| 7. 签 registry root | 绿色 | 整包 registry snapshot 有一个 signed root。 | publish 后签 registry root。 | TypeScript 已经有 signed registry-root。 |
+| 8. 选择并输出外部 anchors | 黄色 | release 产生 registry 外面的 deployment trust manifest。 | 输出 digest、signer policy、Rekor policy、freshness policy、部署片段。 | 模型清楚，CLI/release tooling 要补完。 |
+| 9. runtime 打开 registry | 绿色 | app 启动时用外部 anchor 接受或拒绝 registry。 | 从 app code、deployment config、release metadata 读取 anchors。 | TypeScript 已经支持这个模型。 |
+
+## Anchor 的几种选择
+
+多数使用者不应该自己发明这一步。工具应该让他选一个 profile，然后输出正确
+的文件或片段。
+
+### A. 把 `expectedRootDigest` 固定在 app 里
+
+这是最简单的 anchor。
+
+release 产出 signed registry root 的 digest。application 把这个 digest 放在
+程式码、随 app 打包的 config，或 binary 里。启动时，LLMix 用这个 digest
+检查部署出去的 registry。
+
+适合 app 和 registry 一起发版。
+
+代价是 registry 变了就要重发 app。这不是缺点。它就是边界。
+
+CLI 应该帮忙输出：
+
+- `expectedRootDigest`
+- TypeScript/Python/Rust config snippet
+- 给 AI agent 读的 JSON 结果
+
+### B. 把 `expectedRootDigest` 放在部署配置里
+
+这仍然简单，但比较灵活。
+
+digest 可以放在 `/etc/llmix/trust.json`、Kubernetes config、Terraform
+variables、GitHub Actions deployment outputs、secret manager，或其他部署通道。
+它不一定要保密。重点是它不能在 `config/llm/` 里面。
+
+适合 service 和 registry 可能分开发版的状况。
+
+CLI 应该帮忙输出常见格式：
+
+- JSON trust manifest
+- environment variables
+- Kubernetes ConfigMap 或 Secret snippet
+- GitHub Actions output
+- Terraform variable snippet
+
+### C. GitHub Actions OIDC + Sigstore/Rekor
+
+这个应该是很多团队的默认选择。
+
+不要信任“GitHub repo 里面某个文件”。要信任 release identity：repository、
+ref 或 environment、workflow identity、Sigstore signature、Rekor transparency
+entry。
+
+这跟 npm provenance 的精神很接近。重点不是“有人上传了这个东西”。重点是
+“这个东西来自这个 release workflow”。
+
+适合已经用 GitHub Actions release 的项目。
+
+CLI 应该帮忙输出：
+
+- GitHub Actions signing workflow snippet
+- pin 住 repo、ref、environment、workflow 的 Sigstore/Rekor trust policy
+- signed `.mda` verification result
+- signed registry-root verification result
+- deployment trust manifest
+
+这个 profile 可以取代大多数手写 signer policy 的工作。它不能取消外部 anchor
+的需要。anchor 会变成 pinned policy 和 freshness state。对于静态 release，
+也可以再加一个 `expectedRootDigest`。
+
+### D. KMS/HSM 或 did:web
+
+这是给有更强内部签名要求的团队。
+
+适合公司已经有 cloud KMS、HSM、domain-controlled identity，或 multi-signer
+release policy。它在对的环境里更强，但不是最简单的默认选择。
+
+CLI 应该帮忙生成 policy template，并检查签出来的 signatures 可以真的通过
+verify。
+
+## 推荐默认值
+
+小项目：
+
+1. 用 GitHub Actions OIDC + Sigstore/Rekor。
+2. 同时输出 `expectedRootDigest`。
+3. 把 digest 放进 app config 或 deployment config。
+
+打包型 app：
+
+1. 把 `expectedRootDigest` 固定在 app 里。
+2. registry 随 app read-only ship。
+
+服务型系统：
+
+1. 用 GitHub Actions OIDC + Sigstore/Rekor。
+2. 把 deployment trust manifest 放在 `config/llm/` 外面。
+3. 用 freshness checks 防 rollback。
+
+## Deployment Trust Manifest
+
+release 应该产出两份东西。
+
+```text
+registry bundle
+  config/llm/
+    snapshots/
+    current.json
+
+deployment trust manifest
+  expectedRootDigest
+  registryRootTrustPolicy
+  rekorPolicy
+  minimumRevision
+  minimumPublishedAt
+  highWatermark
+```
+
+第一份可以随 app ship。
+
+第二份 runtime 时必须从别的地方来。app code、deployment config、secret
+manager、GitHub release metadata、KMS-backed config、Kubernetes、Terraform
+都可以。重点不是保密。重点是隔离。
+
+## 这倒推出来的 CLI 工作
+
+现在 CLI 的 authoring 方向是对的：explicit targets、machine-readable JSON、
+validation、compile、canonicalization、integrity checks、conformance checks。
+
+上面的流程倒推出来，下一步要补这些：
+
+1. 完整 `mda sign`。
+2. 完整 cryptographic `mda verify`。
+3. 加 GitHub Actions OIDC + Sigstore/Rekor profile。
+4. 生成 GitHub、KMS/HSM、did:web 的 trust policy templates。
+5. 输出 deployment trust manifest。
+6. 输出常见部署系统的 snippets。
+7. 所有命令都保持 agent-friendly：`--json`、稳定 diagnostics、无法证明 trust
+   时 non-zero exit。
+
+CLI 可以自动化 release 工作。它不应该把 policy 藏进同一个 registry bundle，
+然后假装自己变成 runtime trust anchor。
+
+那只是把锁装到同一扇门上。

--- a/packages/llmix/python/pyproject.toml
+++ b/packages/llmix/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sno-llmix"
-version = "2.0.2"
+version = "2.0.3"
 description = "Cross-runtime LLM orchestration for Python, TypeScript, and Rust with L2 caching, retries, key rotation, and config-driven runtime control"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/llmix/python/pyproject.toml
+++ b/packages/llmix/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sno-llmix"
-version = "2.0.3"
+version = "2.0.4"
 description = "Cross-runtime LLM orchestration for Python, TypeScript, and Rust with L2 caching, retries, key rotation, and config-driven runtime control"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/llmix/rust/Cargo.lock
+++ b/packages/llmix/rust/Cargo.lock
@@ -545,7 +545,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "llmix-rs"
-version = "2.0.2"
+version = "2.0.3"
 dependencies = [
  "async-trait",
  "fs2",

--- a/packages/llmix/rust/Cargo.lock
+++ b/packages/llmix/rust/Cargo.lock
@@ -545,7 +545,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "llmix-rs"
-version = "2.0.3"
+version = "2.0.4"
 dependencies = [
  "async-trait",
  "fs2",

--- a/packages/llmix/rust/Cargo.toml
+++ b/packages/llmix/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llmix-rs"
-version = "2.0.3"
+version = "2.0.4"
 edition = "2021"
 rust-version = "1.83"
 license = "Apache-2.0"

--- a/packages/llmix/rust/Cargo.toml
+++ b/packages/llmix/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llmix-rs"
-version = "2.0.2"
+version = "2.0.3"
 edition = "2021"
 rust-version = "1.83"
 license = "Apache-2.0"

--- a/packages/llmix/typescript/package.json
+++ b/packages/llmix/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snoai/llmix",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Config-driven harness around your LLM SDK. MDA-driven model swap, two-tier cache, circuit breaker, key-pool rotation.",
   "author": "Sno AI",
   "license": "Apache-2.0",

--- a/packages/llmix/typescript/package.json
+++ b/packages/llmix/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snoai/llmix",
-  "version": "2.0.2",
+  "version": "2.0.3",
   "description": "Config-driven harness around your LLM SDK. MDA-driven model swap, two-tier cache, circuit breaker, key-pool rotation.",
   "author": "Sno AI",
   "license": "Apache-2.0",

--- a/uv.lock
+++ b/uv.lock
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "sno-llmix"
-version = "2.0.3"
+version = "2.0.4"
 source = { editable = "packages/llmix/python" }
 dependencies = [
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "sno-llmix"
-version = "2.0.2"
+version = "2.0.3"
 source = { editable = "packages/llmix/python" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

Merge `dev` branch into `main`.

## Version

Family: `llmix`
Version: `2.0.3`

## Commits (2)
```
edd4f92 chore: bump llmix version to 2.0.3
75cb82a docs: update secure LLMix configuration documentation with detailed production registry trust flow and MDA CLI usage
```

## Changed Files
```
bun.lock
docs/llmix/secure-llmix-configuration.md
docs/mda-sign-flow/README.md
docs/mda-sign-flow/README.zh.md
packages/llmix/python/pyproject.toml
packages/llmix/rust/Cargo.lock
packages/llmix/rust/Cargo.toml
packages/llmix/typescript/package.json
uv.lock
```

---
Created: 2026-05-10 23:03:16 UTC
By: Larry Hope
Head Commit: edd4f92
