### PR TITLE
docs(examples): add multi-provider dispatch example

### DIFF
--- a/examples/python/multi_provider.py
+++ b/examples/python/multi_provider.py
@@ -1,0 +1,85 @@
+"""LLMix multi-provider dispatch example.
+
+Shows how to configure multiple providers in a single pipeline and
+dispatch to each independently. The cache and circuit breaker maintain
+separate state per provider.
+
+Run with:
+    OPENAI_API_KEY=sk-... ANTHROPIC_API_KEY=sk-ant-... \
+    uv run python examples/python/multi_provider.py
+"""
+
+import asyncio
+import os
+
+from llmix import (
+    CallInput,
+    CallPipeline,
+    KeyPool,
+    PipelineConfig,
+    TwoTierCache,
+    anthropic_dispatch,
+    openai_dispatch,
+)
+
+
+async def main() -> None:
+    pipeline = CallPipeline(
+        PipelineConfig(
+            dispatch=openai_dispatch(),
+            response_cache=TwoTierCache("memory"),
+        )
+    )
+
+    pipeline.set_key_pool("openai", KeyPool([os.environ["OPENAI_API_KEY"]]))
+    pipeline.set_key_pool(
+        "anthropic", KeyPool([os.environ["ANTHROPIC_API_KEY"]])
+    )
+
+    prompt = "In one sentence, explain what a circuit breaker pattern is."
+
+    # Dispatch to OpenAI
+    openai_resp = await pipeline.call(
+        CallInput(
+            config={
+                "provider": "openai",
+                "model": "gpt-4.1-mini",
+                "common": {"temperature": 0.3, "max_output_tokens": 128},
+                "caching": {"strategy": "memory"},
+            },
+            messages=[{"role": "user", "content": prompt}],
+        )
+    )
+    print(f"[OpenAI]    {openai_resp.content}")
+
+    # Dispatch to Anthropic
+    anthropic_resp = await pipeline.call(
+        CallInput(
+            config={
+                "provider": "anthropic",
+                "model": "claude-sonnet-4-5-20250514",
+                "common": {"temperature": 0.3, "max_output_tokens": 128},
+                "caching": {"strategy": "memory"},
+            },
+            messages=[{"role": "user", "content": prompt}],
+        )
+    )
+    print(f"[Anthropic] {anthropic_resp.content}")
+
+    # Same calls again — should hit cache
+    cached = await pipeline.call(
+        CallInput(
+            config={
+                "provider": "openai",
+                "model": "gpt-4.1-mini",
+                "common": {"temperature": 0.3, "max_output_tokens": 128},
+                "caching": {"strategy": "memory"},
+            },
+            messages=[{"role": "user", "content": prompt}],
+        )
+    )
+    print(f"\n[OpenAI cached] cache_hit={cached.cache_hit}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What

Adds `examples/python/multi_provider.py` showing how to configure and dispatch to multiple LLM providers in a single pipeline.

## Why

The quickstart only shows OpenAI. Many users need to call multiple providers (OpenAI + Anthropic + Gemini) from the same pipeline instance.

## How

Single Python example file. Registers three providers with their key pools and dispatches to each, showing how the cache and circuit breaker work independently per provider.

## Cross-language parity

- [x] Pure docs / examples / scripts (no parity impact)
