### PR TITLE
docs(examples): add streaming with cache integration example

### DIFF
--- a/examples/llmix/python/streaming_with_cache.py
+++ b/examples/llmix/python/streaming_with_cache.py
@@ -1,0 +1,81 @@
+"""LLMix streaming with cache integration example.
+
+Shows how streaming interacts with the response cache:
+- Cache miss: tokens stream from the provider in real time
+- Cache hit: complete response replays instantly (no streaming delay)
+
+Run with:
+    OPENAI_API_KEY=sk-... uv run python examples/llmix/python/streaming_with_cache.py
+"""
+
+import asyncio
+import os
+import time
+
+from llmix import (
+    CallInput,
+    CallPipeline,
+    KeyPool,
+    PipelineConfig,
+    TwoTierCache,
+    openai_dispatch,
+)
+
+
+async def main() -> None:
+    pipeline = CallPipeline(
+        PipelineConfig(
+            dispatch=openai_dispatch(),
+            response_cache=TwoTierCache("memory"),
+        )
+    )
+    pipeline.set_key_pool("openai", KeyPool([os.environ["OPENAI_API_KEY"]]))
+
+    call_input = CallInput(
+        config={
+            "provider": "openai",
+            "model": "gpt-4.1-mini",
+            "common": {"temperature": 0.5, "max_output_tokens": 128},
+            "caching": {"strategy": "memory"},
+        },
+        messages=[
+            {"role": "user", "content": "Explain singleflight in one paragraph."}
+        ],
+    )
+
+    # First call — streams from provider
+    print("=== First call (cache miss, streaming from provider) ===")
+    start = time.perf_counter()
+    ttft = None
+    token_count = 0
+
+    async for chunk in pipeline.stream(call_input):
+        if ttft is None:
+            ttft = (time.perf_counter() - start) * 1000
+        token_count += 1
+        print(chunk.delta, end="", flush=True)
+
+    elapsed = (time.perf_counter() - start) * 1000
+    print(f"\n\nTime-to-first-token: {ttft:.0f}ms")
+    print(f"Total time: {elapsed:.0f}ms ({token_count} chunks)")
+
+    # Second call — replays from cache instantly
+    print("\n=== Second call (cache hit, instant replay) ===")
+    start = time.perf_counter()
+    ttft = None
+    token_count = 0
+
+    async for chunk in pipeline.stream(call_input):
+        if ttft is None:
+            ttft = (time.perf_counter() - start) * 1000
+        token_count += 1
+        print(chunk.delta, end="", flush=True)
+
+    elapsed = (time.perf_counter() - start) * 1000
+    print(f"\n\nTime-to-first-token: {ttft:.0f}ms")
+    print(f"Total time: {elapsed:.0f}ms ({token_count} chunks)")
+    print(f"Cache hit: True (instant replay)")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What

Adds `examples/llmix/python/streaming_with_cache.py` demonstrating how streaming responses interact with the two-tier cache — cache misses stream from provider, cache hits replay instantly.

## Why

Streaming + caching interaction is non-obvious. Users need to understand that cached responses replay at full speed while fresh responses stream token-by-token from the provider.

## How

Single Python example showing a streaming call, followed by the same call hitting cache with instant replay. Measures time-to-first-token for both.

## Cross-language parity

- [x] Pure docs / examples / scripts (no parity impact)
