### PR TITLE
docs(examples): add singleflight deduplication demo

### DIFF
--- a/examples/llmix/python/singleflight_demo.py
+++ b/examples/llmix/python/singleflight_demo.py
@@ -1,0 +1,63 @@
+"""LLMix singleflight deduplication demo.
+
+Demonstrates how concurrent identical requests are coalesced into
+a single provider call. This saves API costs when multiple users
+or goroutines request the same completion simultaneously.
+
+Run with:
+    OPENAI_API_KEY=sk-... uv run python examples/llmix/python/singleflight_demo.py
+"""
+
+import asyncio
+import os
+import time
+
+from llmix import (
+    CallInput,
+    CallPipeline,
+    KeyPool,
+    PipelineConfig,
+    TwoTierCache,
+    openai_dispatch,
+)
+
+
+async def main() -> None:
+    pipeline = CallPipeline(
+        PipelineConfig(
+            dispatch=openai_dispatch(),
+            response_cache=TwoTierCache("memory"),
+            singleflight=True,  # Enable request coalescing
+        )
+    )
+    pipeline.set_key_pool("openai", KeyPool([os.environ["OPENAI_API_KEY"]]))
+
+    config = {
+        "provider": "openai",
+        "model": "gpt-4.1-mini",
+        "common": {"temperature": 0.0, "max_output_tokens": 64},
+        "caching": {"strategy": "memory"},
+    }
+    messages = [{"role": "user", "content": "What is 2 + 2?"}]
+
+    # Fire 10 identical requests concurrently
+    start = time.perf_counter()
+    tasks = [
+        pipeline.call(CallInput(config=config, messages=messages))
+        for _ in range(10)
+    ]
+    results = await asyncio.gather(*tasks)
+    elapsed = time.perf_counter() - start
+
+    # All 10 get the same response, but only 1 API call was made
+    print(f"Completed {len(results)} requests in {elapsed:.2f}s")
+    print(f"Response: {results[0].content}")
+    print(f"\nSingleflight stats:")
+    print(f"  Total requests: {len(results)}")
+    print(f"  Cache hits: {sum(1 for r in results if r.cache_hit)}")
+    print(f"  Coalesced: {sum(1 for r in results if r.coalesced)}")
+    print(f"  Actual API calls: {pipeline.stats.api_calls}")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())


### PR DESCRIPTION
## What

Adds `examples/llmix/python/singleflight_demo.py` demonstrating how singleflight deduplication collapses concurrent identical requests into one provider call.

## Why

Singleflight is a key efficiency feature that saves API costs when multiple users or processes request the same completion simultaneously. No existing example shows this behavior.

## How

Single Python file that fires 10 concurrent identical requests and shows only 1 actual provider call is made, with 9 cache-coalesced responses.

## Cross-language parity

- [x] Pure docs / examples / scripts (no parity impact)
