### PR TITLE
Align registry publisher parity across runtimes

### DIFF
--- a/packages/llmix/python/llmix/config_registry_manager.py
+++ b/packages/llmix/python/llmix/config_registry_manager.py
@@ -131,6 +131,8 @@ class ConfigRegistryManager:
             current_pointer = self._read_current_pointer()
         except Exception as exc:
             self._record_reload_error(exc)
+            if self._should_fail_closed_on_refresh_error():
+                raise
             return
 
         if (
@@ -162,6 +164,11 @@ class ConfigRegistryManager:
                 )
             except Exception as exc:
                 self._record_reload_error(exc)
+                if self._should_fail_closed_on_refresh_error():
+                    raise
+
+    def _should_fail_closed_on_refresh_error(self) -> bool:
+        return self.signed_root_options is not None
 
     def _read_current_pointer(self) -> dict[str, str]:
         pointer = _read_json_file(self.current_path)

--- a/packages/llmix/python/llmix/config_registry_publisher.py
+++ b/packages/llmix/python/llmix/config_registry_publisher.py
@@ -30,6 +30,7 @@ from llmix.config_registry_common import (
     _write_json,
 )
 from llmix.config_registry_root import (
+    _required_signature_count,
     _registry_root_signing_input_for_envelope,
     build_registry_root_payload,
     create_registry_root_envelope,
@@ -290,6 +291,15 @@ class ConfigRegistryPublisher:
                 raise InvalidConfigError(
                     "Registry revision already exists with a registry root signature payload mismatch"
                 )
+        required_signatures = _required_signature_count(
+            registry_root_options.min_signatures
+        )
+        if len(envelope["signatures"]) < required_signatures:
+            raise InvalidConfigError(
+                "Registry revision already exists with "
+                f"{len(envelope['signatures'])} registry root signatures; "
+                f"expected at least {required_signatures}"
+            )
 
         actual_payload = _normalized_registry_root_payload(envelope["payload"])
         expected_payload = _normalized_registry_root_payload(
@@ -298,17 +308,6 @@ class ConfigRegistryPublisher:
         if actual_payload != expected_payload:
             raise InvalidConfigError(
                 "Registry revision already exists with a registry root that does not match the committed manifest"
-            )
-        expected_envelope = create_registry_root_envelope(
-            expected_payload, registry_root_options
-        )
-        if (
-            envelope["integrity"] != expected_envelope["integrity"]
-            or envelope["payload_sha256"] != expected_envelope["payload_sha256"]
-            or envelope["signatures"] != expected_envelope["signatures"]
-        ):
-            raise InvalidConfigError(
-                "Registry revision already exists with a registry root signature mismatch"
             )
 
     def _discover_presets(self) -> list[_PresetSource]:

--- a/packages/llmix/python/llmix/config_registry_publisher.py
+++ b/packages/llmix/python/llmix/config_registry_publisher.py
@@ -4,9 +4,11 @@ from __future__ import annotations
 
 import hashlib
 import logging
+import os
 import shutil
 import threading
 from datetime import datetime
+from itertools import count
 from pathlib import Path
 from typing import Any, cast
 
@@ -28,13 +30,19 @@ from llmix.config_registry_common import (
     _write_json,
 )
 from llmix.config_registry_root import (
+    _registry_root_signing_input_for_envelope,
     build_registry_root_payload,
     create_registry_root_envelope,
+    sorted_registry_root_files,
+)
+from llmix.config_registry_root_parse import (
+    parse_registry_root_envelope,
 )
 from llmix.config_registry_types import (
     REGISTRY_ROOT_FILENAME,
     ConfigRegistryPublishOptions,
     PublishedRevision,
+    RegistryRootSigningOptions,
     _PresetSource,
 )
 from llmix.mda_loader import MdaConfigLoadOptions
@@ -43,12 +51,21 @@ from llmix.types import ConfigNotFoundError, InvalidConfigError, validate_module
 
 logger = logging.getLogger(__name__)
 _PUBLISH_LOCK = threading.RLock()
+_STAGING_COUNTER = count()
 
 
 def _load_mda_config(path: Path, options: MdaConfigLoadOptions | None) -> dict[str, Any]:
     import llmix.config_registry as registry_facade
 
     return cast(dict[str, Any], registry_facade.load_mda_config(path, options))
+
+
+def _normalized_registry_root_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    normalized = dict(payload)
+    normalized["current"] = dict(payload["current"])
+    normalized["manifest"] = dict(payload["manifest"])
+    normalized["files"] = sorted_registry_root_files(payload["files"])
+    return normalized
 
 
 class ConfigRegistryPublisher:
@@ -91,14 +108,8 @@ class ConfigRegistryPublisher:
         _validate_revision(revision_id)
 
         compiled_dir = self.compiled_dir / revision_id
-        stage_dir = self.staging_dir / f"{revision_id}.tmp"
+        stage_dir = self._staging_attempt_path(revision_id, published_at)
         manifest_path = compiled_dir / "manifest.json"
-
-        if compiled_dir.exists():
-            raise InvalidConfigError(f"Registry revision already exists: {revision_id}")
-
-        if stage_dir.exists():
-            shutil.rmtree(stage_dir)
 
         try:
             load_options = (
@@ -116,25 +127,33 @@ class ConfigRegistryPublisher:
                 if options
                 else None
             )
-            manifest = self._build_staged_snapshot(
+            manifest = self._build_staged_revision(
                 stage_dir, presets, revision_id, published_at, load_options
             )
-            self._verify_staged_snapshot(stage_dir, manifest)
+            self._verify_staged_revision(stage_dir, manifest)
             manifest_sha256 = _sha256_file(stage_dir / "manifest.json")
             registry_root_sha256 = self._write_registry_root_if_requested(
                 stage_dir, manifest, manifest_sha256, options
             )
-            compiled_dir.parent.mkdir(parents=True, exist_ok=True)
-            self.staging_dir.mkdir(parents=True, exist_ok=True)
-            stage_dir.rename(compiled_dir)
-            _fsync_dir(compiled_dir.parent)
+            committed_manifest_sha256, committed_registry_root_sha256 = (
+                self._commit_revision(
+                    stage_dir=stage_dir,
+                    compiled_dir=compiled_dir,
+                    expected_manifest=manifest,
+                    manifest_sha256=manifest_sha256,
+                    registry_root_sha256=registry_root_sha256,
+                    registry_root_options=(
+                        options.registry_root if options is not None else None
+                    ),
+                )
+            )
 
             if activate:
                 _atomic_write_json(
                     self.current_path,
                     {
                         "revision": revision_id,
-                        "manifest_sha256": manifest_sha256,
+                        "manifest_sha256": committed_manifest_sha256,
                     },
                 )
                 logger.info("Config Registry activated revision %s", revision_id)
@@ -144,15 +163,15 @@ class ConfigRegistryPublisher:
                 revision=revision_id,
                 compiled_path=compiled_dir,
                 manifest_path=manifest_path,
-                manifest_sha256=manifest_sha256,
+                manifest_sha256=committed_manifest_sha256,
                 activated=activate,
                 preset_ids=tuple(sorted(manifest["presets"].keys())),
                 registry_root_path=(
                     compiled_dir / REGISTRY_ROOT_FILENAME
-                    if registry_root_sha256 is not None
+                    if committed_registry_root_sha256 is not None
                     else None
                 ),
-                registry_root_sha256=registry_root_sha256,
+                registry_root_sha256=committed_registry_root_sha256,
             )
         except Exception:
             if stage_dir.exists():
@@ -174,6 +193,123 @@ class ConfigRegistryPublisher:
         root_path = stage_dir / REGISTRY_ROOT_FILENAME
         _write_json(root_path, envelope)
         return _sha256_file(root_path)
+
+    def _commit_revision(
+        self,
+        *,
+        stage_dir: Path,
+        compiled_dir: Path,
+        expected_manifest: dict[str, Any],
+        manifest_sha256: str,
+        registry_root_sha256: str | None,
+        registry_root_options: RegistryRootSigningOptions | None,
+    ) -> tuple[str, str | None]:
+        compiled_dir.parent.mkdir(parents=True, exist_ok=True)
+        self.staging_dir.mkdir(parents=True, exist_ok=True)
+        try:
+            stage_dir.rename(compiled_dir)
+            _fsync_dir(compiled_dir.parent)
+            return manifest_sha256, registry_root_sha256
+        except OSError:
+            if not compiled_dir.exists():
+                raise
+
+        committed = self._load_matching_existing_revision(
+            compiled_dir=compiled_dir,
+            expected_manifest=expected_manifest,
+            registry_root_sha256=registry_root_sha256,
+            registry_root_options=registry_root_options,
+        )
+        shutil.rmtree(stage_dir, ignore_errors=True)
+        return committed
+
+    def _load_matching_existing_revision(
+        self,
+        *,
+        compiled_dir: Path,
+        expected_manifest: dict[str, Any],
+        registry_root_sha256: str | None,
+        registry_root_options: RegistryRootSigningOptions | None,
+    ) -> tuple[str, str | None]:
+        manifest_path = compiled_dir / "manifest.json"
+        existing_manifest = _read_json_file(manifest_path)
+        self._verify_staged_revision(compiled_dir, existing_manifest)
+
+        if (
+            existing_manifest.get("revision") != expected_manifest.get("revision")
+            or existing_manifest.get("schema_version")
+            != expected_manifest.get("schema_version")
+            or existing_manifest.get("presets") != expected_manifest.get("presets")
+        ):
+            raise InvalidConfigError(
+                f"Registry revision already exists with different contents: {expected_manifest.get('revision')}"
+            )
+
+        existing_manifest_sha256 = _sha256_file(manifest_path)
+        root_path = compiled_dir / REGISTRY_ROOT_FILENAME
+        existing_registry_root_sha256 = (
+            _sha256_file(root_path) if root_path.exists() else None
+        )
+        # Signed roots include publish-time material; same-revision retries must
+        # reuse the already committed root once the manifest contents match.
+        if registry_root_sha256 is not None:
+            if existing_registry_root_sha256 is None:
+                raise InvalidConfigError(
+                    "Registry revision already exists without the requested registry root"
+                )
+            if registry_root_options is None:
+                raise InvalidConfigError(
+                    "Registry revision already exists but no registry root signer is available"
+                )
+            self._verify_existing_registry_root(
+                root_path,
+                existing_manifest,
+                existing_manifest_sha256,
+                registry_root_options,
+            )
+        return existing_manifest_sha256, existing_registry_root_sha256
+
+    def _staging_attempt_path(self, revision_id: str, published_at: datetime) -> Path:
+        stamp = published_at.strftime("%Y%m%dT%H%M%S%fZ")
+        counter = next(_STAGING_COUNTER)
+        return self.staging_dir / f"{revision_id}.{stamp}.{os.getpid()}.{counter}.tmp"
+
+    def _verify_existing_registry_root(
+        self,
+        root_path: Path,
+        manifest: dict[str, Any],
+        manifest_sha256: str,
+        registry_root_options: RegistryRootSigningOptions,
+    ) -> None:
+        envelope = parse_registry_root_envelope(
+            _read_json_file(root_path), str(root_path)
+        )
+        signing_input = _registry_root_signing_input_for_envelope(envelope)
+        for signature in envelope["signatures"]:
+            if signature["payload-digest"] != signing_input.integrity["digest"]:
+                raise InvalidConfigError(
+                    "Registry revision already exists with a registry root signature payload mismatch"
+                )
+
+        actual_payload = _normalized_registry_root_payload(envelope["payload"])
+        expected_payload = _normalized_registry_root_payload(
+            build_registry_root_payload(manifest, manifest_sha256)
+        )
+        if actual_payload != expected_payload:
+            raise InvalidConfigError(
+                "Registry revision already exists with a registry root that does not match the committed manifest"
+            )
+        expected_envelope = create_registry_root_envelope(
+            expected_payload, registry_root_options
+        )
+        if (
+            envelope["integrity"] != expected_envelope["integrity"]
+            or envelope["payload_sha256"] != expected_envelope["payload_sha256"]
+            or envelope["signatures"] != expected_envelope["signatures"]
+        ):
+            raise InvalidConfigError(
+                "Registry revision already exists with a registry root signature mismatch"
+            )
 
     def _discover_presets(self) -> list[_PresetSource]:
         if not self.source_dir.exists():
@@ -233,7 +369,7 @@ class ConfigRegistryPublisher:
         timestamp = published_at.strftime("%Y-%m-%dT%H-%M-%SZ")
         return f"{timestamp}_{digest.hexdigest()[:8]}"
 
-    def _build_staged_snapshot(
+    def _build_staged_revision(
         self,
         stage_dir: Path,
         presets: list[_PresetSource],
@@ -272,7 +408,7 @@ class ConfigRegistryPublisher:
         _write_json(stage_dir / "manifest.json", manifest)
         return manifest
 
-    def _verify_staged_snapshot(
+    def _verify_staged_revision(
         self, stage_dir: Path, manifest: dict[str, Any]
     ) -> None:
         stored_manifest = _read_json_file(stage_dir / "manifest.json")

--- a/packages/llmix/python/tests/test_config_registry.py
+++ b/packages/llmix/python/tests/test_config_registry.py
@@ -29,7 +29,7 @@ def _canonical_json_bytes(value: dict[str, Any]) -> bytes:
     return (json.dumps(value, indent=2, sort_keys=True) + "\n").encode("utf-8")
 
 
-def _write_authoring_preset(
+def _write_source_preset(
     root: Path,
     module: str,
     preset: str,
@@ -116,7 +116,7 @@ def _trust_policy(subject: str = "releases@snoai.com") -> dict[str, Any]:
     }
 
 
-def _write_signed_authoring_preset(root: Path) -> dict[str, str]:
+def _write_signed_source_preset(root: Path) -> dict[str, str]:
     path = root / "source" / "search" / "summary.mda"
     path.parent.mkdir(parents=True, exist_ok=True)
     body = "# summary\n"
@@ -175,7 +175,7 @@ def test_publish_creates_active_revision_and_manager_reads_resolved_json(
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(
+    _write_source_preset(
         root,
         "search",
         "summary",
@@ -200,10 +200,10 @@ def test_publish_creates_active_revision_and_manager_reads_resolved_json(
     assert "search/summary" in manager.available_presets()
     assert manager.last_successful_reload_at is not None
     assert manager.last_reload_failure_at is None
-    snapshot_dir = root / "compiled" / published.revision
-    assert (snapshot_dir / "source" / "search" / "summary.mda").exists()
+    revision_dir = root / "compiled" / published.revision
+    assert (revision_dir / "source" / "search" / "summary.mda").exists()
     resolved = json.loads(
-        (snapshot_dir / "resolved" / "search" / "summary.json").read_text(
+        (revision_dir / "resolved" / "search" / "summary.json").read_text(
             encoding="utf-8"
         )
     )
@@ -213,14 +213,14 @@ def test_publish_creates_active_revision_and_manager_reads_resolved_json(
 
 def test_manager_reloads_after_current_revision_changes(tmp_path: Path) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(
+    _write_source_preset(
         root, "search", "summary", model="gpt-4.1-mini", temperature=0.2
     )
 
     first = ConfigRegistryPublisher(root).publish()
     manager = ConfigRegistryManager.open(root)
 
-    _write_authoring_preset(
+    _write_source_preset(
         root, "search", "summary", model="gpt-5-mini", temperature=0.9
     )
     second = ConfigRegistryPublisher(root).publish()
@@ -237,29 +237,94 @@ def test_available_presets_refreshes_after_current_revision_changes(
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(root, "search", "summary")
+    _write_source_preset(root, "search", "summary")
 
     ConfigRegistryPublisher(root).publish()
     manager = ConfigRegistryManager.open(root)
 
-    _write_authoring_preset(root, "rerank", "default")
+    _write_source_preset(root, "rerank", "default")
     ConfigRegistryPublisher(root).publish()
 
     assert manager.available_presets() == ("rerank/default", "search/summary")
 
 
-def test_manager_rolls_back_when_current_revision_points_to_older_snapshot(
+def test_publish_same_revision_from_same_source_is_idempotent(tmp_path: Path) -> None:
+    root = tmp_path / "config" / "llm"
+    _write_source_preset(root, "search", "summary")
+    publisher = ConfigRegistryPublisher(root)
+
+    first = publisher.publish(revision="manual", activate=False)
+    second = publisher.publish(revision="manual", activate=True)
+    manager = ConfigRegistryManager.open(root)
+
+    assert first.manifest_sha256 == second.manifest_sha256
+    assert second.revision == "manual"
+    assert second.activated is True
+    assert manager.active_revision == "manual"
+    assert manager.get_preset("search", "summary")["model"] == "gpt-4.1-mini"
+
+
+def test_publish_same_revision_with_different_source_fails(tmp_path: Path) -> None:
+    root = tmp_path / "config" / "llm"
+    _write_source_preset(root, "search", "summary", model="gpt-4.1-mini")
+    publisher = ConfigRegistryPublisher(root)
+    publisher.publish(revision="manual", activate=False)
+
+    _write_source_preset(root, "search", "summary", model="gpt-5-mini")
+
+    with pytest.raises(InvalidConfigError, match="different contents"):
+        publisher.publish(revision="manual", activate=False)
+
+
+def test_publish_retry_after_current_write_failure_reuses_compiled_revision(
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(
+    _write_source_preset(root, "search", "summary")
+    (root / "current.json").mkdir(parents=True)
+    publisher = ConfigRegistryPublisher(root)
+
+    with pytest.raises(OSError):
+        publisher.publish(revision="manual", activate=True)
+
+    assert (root / "compiled" / "manual" / "manifest.json").is_file()
+    (root / "current.json").rmdir()
+    published = publisher.publish(revision="manual", activate=True)
+    manager = ConfigRegistryManager.open(root)
+
+    assert published.revision == "manual"
+    assert published.activated is True
+    assert manager.active_revision == "manual"
+    assert manager.get_preset("search", "summary")["model"] == "gpt-4.1-mini"
+
+
+def test_publish_uses_unique_staging_dir_for_explicit_revision(tmp_path: Path) -> None:
+    root = tmp_path / "config" / "llm"
+    _write_source_preset(root, "search", "summary")
+    stale_stage_file = root / "compiled" / ".staging" / "manual.tmp" / "sentinel"
+    stale_stage_file.parent.mkdir(parents=True, exist_ok=True)
+    stale_stage_file.write_text("keep", encoding="utf-8")
+
+    published = ConfigRegistryPublisher(root).publish(
+        revision="manual", activate=False
+    )
+
+    assert published.revision == "manual"
+    assert stale_stage_file.is_file()
+
+
+def test_manager_rolls_back_when_current_revision_points_to_older_revision(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "config" / "llm"
+    _write_source_preset(
         root, "search", "summary", model="gpt-4.1-mini", temperature=0.2
     )
 
     first = ConfigRegistryPublisher(root).publish()
     manager = ConfigRegistryManager.open(root)
 
-    _write_authoring_preset(
+    _write_source_preset(
         root, "search", "summary", model="gpt-5-mini", temperature=0.9
     )
     second = ConfigRegistryPublisher(root).publish()
@@ -283,18 +348,18 @@ def test_manager_rolls_back_when_current_revision_points_to_older_snapshot(
     assert config["common"]["temperature"] == 0.2
 
 
-def test_manager_ignores_authoring_edits_until_a_new_revision_is_published(
+def test_manager_ignores_source_edits_until_a_new_revision_is_published(
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(
+    _write_source_preset(
         root, "search", "summary", model="gpt-4.1-mini", temperature=0.2
     )
 
     published = ConfigRegistryPublisher(root).publish()
     manager = ConfigRegistryManager.open(root)
 
-    _write_authoring_preset(
+    _write_source_preset(
         root, "search", "summary", model="gpt-5-mini", temperature=0.9
     )
     config = manager.get_preset("search", "summary")
@@ -308,7 +373,7 @@ def test_manager_reads_resolved_json_without_mda_loader_hot_path(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(root, "search", "summary")
+    _write_source_preset(root, "search", "summary")
     ConfigRegistryPublisher(root).publish()
 
     def fail_loader(*_args: object, **_kwargs: object) -> None:
@@ -341,7 +406,7 @@ def test_manager_opens_legacy_current_pointer_without_manifest_hash(
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(root, "search", "summary", model="gpt-4.1-mini")
+    _write_source_preset(root, "search", "summary", model="gpt-4.1-mini")
     published = ConfigRegistryPublisher(root).publish()
     (root / "current.json").write_text(
         json.dumps({"revision": published.revision}) + "\n", encoding="utf-8"
@@ -359,7 +424,7 @@ def test_manager_keeps_last_known_good_config_when_pointer_changes_to_missing_re
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(
+    _write_source_preset(
         root, "search", "summary", model="gpt-4.1-mini", temperature=0.2
     )
 
@@ -384,7 +449,7 @@ def test_manager_keeps_last_known_good_config_when_pointer_changes_to_missing_re
 
 def test_publish_failure_leaves_active_revision_unchanged(tmp_path: Path) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(
+    _write_source_preset(
         root, "search", "summary", model="gpt-4.1-mini", temperature=0.2
     )
 
@@ -405,11 +470,11 @@ def test_publish_failure_leaves_active_revision_unchanged(tmp_path: Path) -> Non
     )
 
 
-def test_legacy_yaml_authoring_blocks_publish_without_changing_active_revision(
+def test_legacy_yaml_source_blocks_publish_without_changing_active_revision(
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(root, "search", "summary")
+    _write_source_preset(root, "search", "summary")
     first = ConfigRegistryPublisher(root).publish()
 
     legacy_path = root / "source" / "search" / "legacy.yaml"
@@ -422,15 +487,15 @@ def test_legacy_yaml_authoring_blocks_publish_without_changing_active_revision(
     assert pointer["revision"] == first.revision
 
 
-def test_publish_rejects_authoring_module_symlink_escape(tmp_path: Path) -> None:
+def test_publish_rejects_source_module_symlink_escape(tmp_path: Path) -> None:
     root = tmp_path / "config" / "llm"
     outside_root = tmp_path / "outside"
-    _write_authoring_preset(outside_root, "search", "summary")
+    _write_source_preset(outside_root, "search", "summary")
 
-    authoring_dir = root / "source"
-    authoring_dir.mkdir(parents=True)
+    source_dir = root / "source"
+    source_dir.mkdir(parents=True)
     try:
-        (authoring_dir / "search").symlink_to(
+        (source_dir / "search").symlink_to(
             outside_root / "source" / "search", target_is_directory=True
         )
     except OSError:
@@ -440,9 +505,9 @@ def test_publish_rejects_authoring_module_symlink_escape(tmp_path: Path) -> None
         ConfigRegistryPublisher(root).publish()
 
 
-def test_publish_rejects_authoring_file_symlink_escape(tmp_path: Path) -> None:
+def test_publish_rejects_source_file_symlink_escape(tmp_path: Path) -> None:
     root = tmp_path / "config" / "llm"
-    outside_path = _write_authoring_preset(tmp_path / "outside", "search", "summary")
+    outside_path = _write_source_preset(tmp_path / "outside", "search", "summary")
     module_dir = root / "source" / "search"
     module_dir.mkdir(parents=True)
 
@@ -457,7 +522,7 @@ def test_publish_rejects_authoring_file_symlink_escape(tmp_path: Path) -> None:
 
 def test_publish_can_enforce_mda_integrity(tmp_path: Path) -> None:
     root = tmp_path / "config" / "llm"
-    path = _write_authoring_preset(root, "search", "summary")
+    path = _write_source_preset(root, "search", "summary")
     text = path.read_text(encoding="utf-8")
     path.write_text(
         text.replace(
@@ -477,7 +542,7 @@ def test_publish_passes_mda_verification_options(
     tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(root, "search", "summary")
+    _write_source_preset(root, "search", "summary")
     captured: list[Any] = []
 
     def fake_load_mda_config(_path: Path, options: Any = None) -> dict[str, Any]:
@@ -518,7 +583,7 @@ def test_publish_passes_mda_verification_options(
 
 def test_registry_publish_verify_signatures_happy_path(tmp_path: Path) -> None:
     root = tmp_path / "config" / "llm"
-    integrity = _write_signed_authoring_preset(root)
+    integrity = _write_signed_source_preset(root)
 
     published = ConfigRegistryPublisher(root).publish(
         options=ConfigRegistryPublishOptions(
@@ -536,7 +601,7 @@ def test_registry_publish_verify_signatures_happy_path(tmp_path: Path) -> None:
 
 def test_registry_publish_verify_signatures_fail_closed(tmp_path: Path) -> None:
     root = tmp_path / "config" / "llm"
-    integrity = _write_signed_authoring_preset(root)
+    integrity = _write_signed_source_preset(root)
 
     with pytest.raises(InvalidConfigError):
         ConfigRegistryPublisher(root).publish(
@@ -549,9 +614,9 @@ def test_registry_publish_verify_signatures_fail_closed(tmp_path: Path) -> None:
         )
 
 
-def test_manager_rejects_tampered_resolved_snapshot_on_startup(tmp_path: Path) -> None:
+def test_manager_rejects_tampered_resolved_revision_on_startup(tmp_path: Path) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(
+    _write_source_preset(
         root, "search", "summary", model="gpt-4.1-mini", temperature=0.2
     )
 
@@ -569,14 +634,14 @@ def test_manager_rejects_tampered_resolved_snapshot_on_startup(tmp_path: Path) -
 
 def test_manager_revalidates_resolved_json_shape_on_startup(tmp_path: Path) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(
+    _write_source_preset(
         root, "search", "summary", model="gpt-4.1-mini", temperature=0.2
     )
 
     published = ConfigRegistryPublisher(root).publish()
-    snapshot_dir = root / "compiled" / published.revision
-    manifest_path = snapshot_dir / "manifest.json"
-    resolved_path = snapshot_dir / "resolved" / "search" / "summary.json"
+    revision_dir = root / "compiled" / published.revision
+    manifest_path = revision_dir / "manifest.json"
+    resolved_path = revision_dir / "resolved" / "search" / "summary.json"
     resolved = json.loads(resolved_path.read_text(encoding="utf-8"))
     resolved["common"]["temperature"] = 3
     resolved_bytes = _canonical_json_bytes(resolved)

--- a/packages/llmix/python/tests/test_config_registry_trusted_root.py
+++ b/packages/llmix/python/tests/test_config_registry_trusted_root.py
@@ -24,7 +24,7 @@ from llmix import (
     load_llmix_trust_manifest,
     registry_root_options_from_trust_manifest,
 )
-from llmix.config_registry_types import REGISTRY_ROOT_PAYLOAD_TYPE
+from llmix.config_registry_types import REGISTRY_ROOT_FILENAME, REGISTRY_ROOT_PAYLOAD_TYPE
 from llmix.config_registry_root_parse import parse_registry_root_envelope
 from llmix.types import InvalidConfigError, SecurityError
 
@@ -136,7 +136,7 @@ def _open_options(
     )
 
 
-def _write_authoring_preset(
+def _write_source_preset(
     root: Path,
     *,
     model: str = "gpt-4.1-mini",
@@ -164,7 +164,7 @@ def _write_authoring_preset(
     return path
 
 
-def _write_signed_authoring_preset(root: Path) -> Path:
+def _write_signed_source_preset(root: Path) -> Path:
     path = root / "source" / "search" / "summary.mda"
     path.parent.mkdir(parents=True, exist_ok=True)
     body = "# signed summary\n"
@@ -190,10 +190,10 @@ def _write_signed_authoring_preset(root: Path) -> Path:
     signed["signatures"] = [
         {
             "signer": f"did-web:{DOMAIN}",
-            "key-id": f"did:web:{DOMAIN}#authoring",
+            "key-id": f"did:web:{DOMAIN}#source",
             "payload-digest": digest,
             "algorithm": "ed25519",
-            "signature": "fixture-authoring-signature",
+            "signature": "fixture-source-signature",
             "payload-type": DEFAULT_PAYLOAD_TYPE,
         }
     ]
@@ -212,8 +212,12 @@ def _write_json(path: Path, value: dict[str, Any]) -> None:
     path.write_text(json.dumps(value, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
+def _sha256_file(path: Path) -> str:
+    return hashlib.sha256(path.read_bytes()).hexdigest()
+
+
 def _publish_signed_registry(root: Path, revision: str = "rev-1") -> None:
-    _write_authoring_preset(root)
+    _write_source_preset(root)
     ConfigRegistryPublisher(root).publish(revision=revision, options=_publish_options())
 
 
@@ -221,7 +225,7 @@ def test_publish_writes_signed_registry_root_and_manager_opens_it(
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(root, model="gpt-5-mini", temperature=0.7)
+    _write_source_preset(root, model="gpt-5-mini", temperature=0.7)
     verifier = RootDidWebVerifier()
 
     published = ConfigRegistryPublisher(root).publish(
@@ -254,7 +258,7 @@ def test_signed_registry_root_opens_legacy_pretty_canonical_payload(
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(root)
+    _write_source_preset(root)
 
     published = ConfigRegistryPublisher(root).publish(
         revision="rev-1", options=_publish_options()
@@ -271,7 +275,7 @@ def test_signed_registry_root_opens_legacy_pretty_canonical_payload(
 
 def test_publish_passes_trusted_runtime_options_to_mda_loader(tmp_path: Path) -> None:
     root = tmp_path / "config" / "llm"
-    _write_signed_authoring_preset(root)
+    _write_signed_source_preset(root)
     verifier = RootDidWebVerifier(expected_payload_type=DEFAULT_PAYLOAD_TYPE)
 
     published = ConfigRegistryPublisher(root).publish(
@@ -334,7 +338,7 @@ def test_registry_root_parser_rejects_current_binding_digest_mismatch(
 
 def test_unsigned_registry_rejects_manifest_digest_mismatch(tmp_path: Path) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(root)
+    _write_source_preset(root)
     published = ConfigRegistryPublisher(root).publish(revision="rev-1")
     manifest = _read_json(published.manifest_path)
     manifest["published_at"] = "2999-01-01T00:00:00Z"
@@ -386,7 +390,7 @@ def test_signed_registry_root_expected_digest_pins_published_artifact(
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(root)
+    _write_source_preset(root)
     published = ConfigRegistryPublisher(root).publish(
         revision="rev-1", options=_publish_options()
     )
@@ -401,11 +405,110 @@ def test_signed_registry_root_expected_digest_pins_published_artifact(
         ConfigRegistryManager.open(root, _open_options(expected_root_digest="0" * 64))
 
 
+def test_signed_registry_root_refresh_fails_closed_when_trust_anchor_stays_pinned(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "config" / "llm"
+    _write_source_preset(root, model="gpt-4.1-mini")
+    first = ConfigRegistryPublisher(root).publish(
+        revision="rev-1", options=_publish_options()
+    )
+    assert first.registry_root_sha256 is not None
+    manager = ConfigRegistryManager.open(
+        root, _open_options(expected_root_digest=first.registry_root_sha256)
+    )
+
+    _write_source_preset(root, model="gpt-5-mini")
+    second = ConfigRegistryPublisher(root).publish(
+        revision="rev-2", options=_publish_options()
+    )
+
+    assert second.registry_root_sha256 != first.registry_root_sha256
+    with pytest.raises(SecurityError, match="expected_root_digest"):
+        manager.available_presets()
+    assert manager.active_revision == "rev-1"
+    assert manager.last_reload_error is not None
+
+
+def test_signed_publish_retry_after_current_write_failure_reuses_compiled_root(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "config" / "llm"
+    _write_source_preset(root, model="gpt-4.1-mini")
+    (root / "current.json").mkdir(parents=True)
+
+    publisher = ConfigRegistryPublisher(root)
+    with pytest.raises(OSError):
+        publisher.publish(revision="rev-1", options=_publish_options())
+
+    root_path = root / "compiled" / "rev-1" / REGISTRY_ROOT_FILENAME
+    committed_root_bytes = root_path.read_bytes()
+    committed_root_sha256 = _sha256_file(root_path)
+
+    (root / "current.json").rmdir()
+    published = publisher.publish(revision="rev-1", options=_publish_options())
+    manager = ConfigRegistryManager.open(
+        root, _open_options(expected_root_digest=published.registry_root_sha256)
+    )
+    config = manager.get_preset("search", "summary")
+
+    assert published.registry_root_path == root_path
+    assert published.registry_root_sha256 == committed_root_sha256
+    assert root_path.read_bytes() == committed_root_bytes
+    assert config["model"] == "gpt-4.1-mini"
+
+
+def test_signed_publish_retry_rejects_corrupted_committed_registry_root(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "config" / "llm"
+    _write_source_preset(root, model="gpt-4.1-mini")
+    (root / "current.json").mkdir(parents=True)
+
+    publisher = ConfigRegistryPublisher(root)
+    with pytest.raises(OSError):
+        publisher.publish(revision="rev-1", options=_publish_options())
+
+    root_path = root / "compiled" / "rev-1" / REGISTRY_ROOT_FILENAME
+    envelope = _read_json(root_path)
+    envelope["payload"]["files"] = []
+    _write_json(root_path, envelope)
+
+    (root / "current.json").rmdir()
+    with pytest.raises(InvalidConfigError, match="Registry root"):
+        publisher.publish(revision="rev-1", options=_publish_options())
+
+    assert not (root / "current.json").exists()
+
+
+def test_signed_publish_retry_rejects_corrupted_committed_registry_root_signature(
+    tmp_path: Path,
+) -> None:
+    root = tmp_path / "config" / "llm"
+    _write_source_preset(root, model="gpt-4.1-mini")
+    (root / "current.json").mkdir(parents=True)
+
+    publisher = ConfigRegistryPublisher(root)
+    with pytest.raises(OSError):
+        publisher.publish(revision="rev-1", options=_publish_options())
+
+    root_path = root / "compiled" / "rev-1" / REGISTRY_ROOT_FILENAME
+    envelope = _read_json(root_path)
+    envelope["signatures"][0]["signature"] = "tampered-registry-root-signature"
+    _write_json(root_path, envelope)
+
+    (root / "current.json").rmdir()
+    with pytest.raises(InvalidConfigError, match="signature mismatch"):
+        publisher.publish(revision="rev-1", options=_publish_options())
+
+    assert not (root / "current.json").exists()
+
+
 def test_signed_registry_root_opens_from_cli_trust_manifest_schema(
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "config" / "llm"
-    _write_authoring_preset(root)
+    _write_source_preset(root)
     published = ConfigRegistryPublisher(root).publish(
         revision="rev-1", options=_publish_options()
     )
@@ -472,7 +575,7 @@ def test_failed_registry_root_signing_does_not_activate_new_revision(
     root = tmp_path / "config" / "llm"
     _publish_signed_registry(root, revision="rev-1")
     before = _read_json(root / "current.json")
-    _write_authoring_preset(root, model="gpt-5-mini")
+    _write_source_preset(root, model="gpt-5-mini")
 
     def fail_signer(_: RegistryRootSigningInput) -> dict[str, Any]:
         raise InvalidConfigError("signing backend unavailable")

--- a/packages/llmix/python/tests/test_config_registry_trusted_root.py
+++ b/packages/llmix/python/tests/test_config_registry_trusted_root.py
@@ -436,17 +436,31 @@ def test_signed_publish_retry_after_current_write_failure_reuses_compiled_root(
     root = tmp_path / "config" / "llm"
     _write_source_preset(root, model="gpt-4.1-mini")
     (root / "current.json").mkdir(parents=True)
+    signature_counter = 0
+
+    def nondeterministic_signer(
+        input_value: RegistryRootSigningInput,
+    ) -> dict[str, Any]:
+        nonlocal signature_counter
+        signature_counter += 1
+        signature = _root_signer(input_value)
+        signature["signature"] = f"fixture-registry-root-signature-{signature_counter}"
+        return signature
+
+    options = ConfigRegistryPublishOptions(
+        registry_root=RegistryRootSigningOptions(signer=nondeterministic_signer)
+    )
 
     publisher = ConfigRegistryPublisher(root)
     with pytest.raises(OSError):
-        publisher.publish(revision="rev-1", options=_publish_options())
+        publisher.publish(revision="rev-1", options=options)
 
     root_path = root / "compiled" / "rev-1" / REGISTRY_ROOT_FILENAME
     committed_root_bytes = root_path.read_bytes()
     committed_root_sha256 = _sha256_file(root_path)
 
     (root / "current.json").rmdir()
-    published = publisher.publish(revision="rev-1", options=_publish_options())
+    published = publisher.publish(revision="rev-1", options=options)
     manager = ConfigRegistryManager.open(
         root, _open_options(expected_root_digest=published.registry_root_sha256)
     )
@@ -481,7 +495,7 @@ def test_signed_publish_retry_rejects_corrupted_committed_registry_root(
     assert not (root / "current.json").exists()
 
 
-def test_signed_publish_retry_rejects_corrupted_committed_registry_root_signature(
+def test_signed_publish_retry_rejects_corrupted_committed_registry_root_signature_digest(
     tmp_path: Path,
 ) -> None:
     root = tmp_path / "config" / "llm"
@@ -494,11 +508,11 @@ def test_signed_publish_retry_rejects_corrupted_committed_registry_root_signatur
 
     root_path = root / "compiled" / "rev-1" / REGISTRY_ROOT_FILENAME
     envelope = _read_json(root_path)
-    envelope["signatures"][0]["signature"] = "tampered-registry-root-signature"
+    envelope["signatures"][0]["payload-digest"] = "sha256:" + ("0" * 64)
     _write_json(root_path, envelope)
 
     (root / "current.json").rmdir()
-    with pytest.raises(InvalidConfigError, match="signature mismatch"):
+    with pytest.raises(InvalidConfigError, match="signature payload mismatch"):
         publisher.publish(revision="rev-1", options=_publish_options())
 
     assert not (root / "current.json").exists()

--- a/packages/llmix/python/tests/test_mda_config_e2e_trust_anchor.py
+++ b/packages/llmix/python/tests/test_mda_config_e2e_trust_anchor.py
@@ -190,7 +190,7 @@ def test_e2e_signed_mda_and_registry_root_loads_expected_config(tmp_path: Path) 
     print("LOADED_CONFIG_JSON=" + json.dumps(loaded, sort_keys=True))
 
 
-def test_e2e_rejects_partially_tampered_signed_mda_and_snapshot(tmp_path: Path) -> None:
+def test_e2e_rejects_partially_tampered_signed_mda_and_revision(tmp_path: Path) -> None:
     root = tmp_path / "partial-tamper"
     source_path = _write_signed_mda(root)
     source_path.write_text(
@@ -212,7 +212,7 @@ def test_e2e_rejects_partially_tampered_signed_mda_and_snapshot(tmp_path: Path) 
             ),
         )
 
-    clean_root = tmp_path / "partial-snapshot-tamper"
+    clean_root = tmp_path / "partial-revision-tamper"
     _write_signed_mda(clean_root)
     published = ConfigRegistryPublisher(clean_root).publish(
         revision="2026-05-10.1", options=_publish_options()
@@ -241,11 +241,11 @@ def test_e2e_rejects_whole_registry_swap_signed_by_untrusted_anchor(tmp_path: Pa
     (trusted_root / "current.json").write_text(
         (attacker_root / "current.json").read_text(encoding="utf-8"), encoding="utf-8"
     )
-    target_snapshot = trusted_root / "compiled" / attacker.revision
-    target_snapshot.parent.mkdir(parents=True, exist_ok=True)
+    target_compiled = trusted_root / "compiled" / attacker.revision
+    target_compiled.parent.mkdir(parents=True, exist_ok=True)
     for path in (attacker_root / "compiled" / attacker.revision).rglob("*"):
         if path.is_file():
-            copied = target_snapshot / path.relative_to(attacker.compiled_path)
+            copied = target_compiled / path.relative_to(attacker.compiled_path)
             copied.parent.mkdir(parents=True, exist_ok=True)
             copied.write_bytes(path.read_bytes())
 

--- a/packages/llmix/rust/src/config_registry/manager.rs
+++ b/packages/llmix/rust/src/config_registry/manager.rs
@@ -178,16 +178,55 @@ impl ConfigRegistryManager {
 
     fn handle_reload_error(&mut self, error: LlmixError) -> LlmixResult<()> {
         let fail_closed = self.open_options.signed_root.is_some();
-        let message = error.to_string();
-        self.last_reload_error = Some(error);
         self.last_reload_failure_at = Some(SystemTime::now());
         if fail_closed {
-            return Err(InvalidConfigError {
-                message: format!("Config Registry refresh failed: {message}"),
-            }
-            .into());
+            self.last_reload_error = Some(reload_error_snapshot(&error));
+            return Err(error);
         }
+        self.last_reload_error = Some(error);
         Ok(())
+    }
+}
+
+fn reload_error_snapshot(error: &LlmixError) -> LlmixError {
+    match error {
+        LlmixError::InvalidResponseCacheConfig(message) => {
+            LlmixError::InvalidResponseCacheConfig(message.clone())
+        }
+        LlmixError::InvalidKeyPoolConfig(message) => {
+            LlmixError::InvalidKeyPoolConfig(message.clone())
+        }
+        LlmixError::InvalidAdaptiveSemaphoreConfig(message) => {
+            LlmixError::InvalidAdaptiveSemaphoreConfig(message.clone())
+        }
+        LlmixError::InvalidRetryPolicyConfig(message) => {
+            LlmixError::InvalidRetryPolicyConfig(message.clone())
+        }
+        LlmixError::InvalidFileLockConfig(message) => {
+            LlmixError::InvalidFileLockConfig(message.clone())
+        }
+        LlmixError::InvalidProviderKwargsConfig(message) => {
+            LlmixError::InvalidProviderKwargsConfig(message.clone())
+        }
+        LlmixError::Redis(message) => LlmixError::Redis(message.clone()),
+        LlmixError::UnknownKeyPoolKey(key) => LlmixError::UnknownKeyPoolKey(key.clone()),
+        LlmixError::CircuitOpen(error) => error.clone().into(),
+        LlmixError::KillSwitchActive(error) => error.clone().into(),
+        LlmixError::KeyPoolExhausted(error) => error.clone().into(),
+        LlmixError::ConfigNotFound(error) => error.clone().into(),
+        LlmixError::ConfigAccess(error) => error.clone().into(),
+        LlmixError::InvalidConfig(error) => error.clone().into(),
+        LlmixError::Security(error) => error.clone().into(),
+        LlmixError::AdaptiveSemaphoreClosed(error) => (*error).into(),
+        LlmixError::Provider(error) => error.clone().into(),
+        LlmixError::CanonicalJson(error) => InvalidConfigError {
+            message: error.to_string(),
+        }
+        .into(),
+        LlmixError::Io(error) => InvalidConfigError {
+            message: error.to_string(),
+        }
+        .into(),
     }
 }
 

--- a/packages/llmix/rust/src/config_registry/manager.rs
+++ b/packages/llmix/rust/src/config_registry/manager.rs
@@ -110,8 +110,9 @@ impl ConfigRegistryManager {
         self.last_reload_failure_at
     }
 
-    pub fn available_presets(&self) -> Vec<String> {
-        self.configs.keys().cloned().collect()
+    pub fn available_presets(&mut self) -> LlmixResult<Vec<String>> {
+        self.refresh_if_needed()?;
+        Ok(self.configs.keys().cloned().collect())
     }
 
     pub fn get_preset<S1, S2>(&mut self, module: S1, preset: S2) -> LlmixResult<Value>
@@ -124,7 +125,7 @@ impl ConfigRegistryManager {
         validate_module(module)?;
         validate_preset(preset)?;
 
-        self.refresh_if_needed();
+        self.refresh_if_needed()?;
 
         let preset_id = format!("{module}/{preset}");
         self.configs.get(&preset_id).cloned().ok_or_else(|| {
@@ -138,13 +139,11 @@ impl ConfigRegistryManager {
         })
     }
 
-    fn refresh_if_needed(&mut self) {
+    fn refresh_if_needed(&mut self) -> LlmixResult<()> {
         let current_pointer = match read_current_pointer(&self.current_path, &self.compiled_dir) {
             Ok(value) => value,
             Err(error) => {
-                self.last_reload_error = Some(error);
-                self.last_reload_failure_at = Some(SystemTime::now());
-                return;
+                return self.handle_reload_error(error);
             }
         };
 
@@ -155,7 +154,7 @@ impl ConfigRegistryManager {
         if current_pointer.revision == self.active_revision
             && current_manifest_sha256 == self.active_manifest_sha256
         {
-            return;
+            return Ok(());
         }
 
         match load_revision(
@@ -171,12 +170,24 @@ impl ConfigRegistryManager {
                 self.last_reload_error = None;
                 self.last_successful_reload_at = Some(SystemTime::now());
                 self.last_reload_failure_at = None;
+                Ok(())
             }
-            Err(error) => {
-                self.last_reload_error = Some(error);
-                self.last_reload_failure_at = Some(SystemTime::now());
-            }
+            Err(error) => self.handle_reload_error(error),
         }
+    }
+
+    fn handle_reload_error(&mut self, error: LlmixError) -> LlmixResult<()> {
+        let fail_closed = self.open_options.signed_root.is_some();
+        let message = error.to_string();
+        self.last_reload_error = Some(error);
+        self.last_reload_failure_at = Some(SystemTime::now());
+        if fail_closed {
+            return Err(InvalidConfigError {
+                message: format!("Config Registry refresh failed: {message}"),
+            }
+            .into());
+        }
+        Ok(())
     }
 }
 

--- a/packages/llmix/rust/src/config_registry/manager.rs
+++ b/packages/llmix/rust/src/config_registry/manager.rs
@@ -110,9 +110,8 @@ impl ConfigRegistryManager {
         self.last_reload_failure_at
     }
 
-    pub fn available_presets(&mut self) -> LlmixResult<Vec<String>> {
-        self.refresh_if_needed()?;
-        Ok(self.configs.keys().cloned().collect())
+    pub fn available_presets(&self) -> Vec<String> {
+        self.configs.keys().cloned().collect()
     }
 
     pub fn get_preset<S1, S2>(&mut self, module: S1, preset: S2) -> LlmixResult<Value>

--- a/packages/llmix/rust/src/config_registry/publisher.rs
+++ b/packages/llmix/rust/src/config_registry/publisher.rs
@@ -5,7 +5,10 @@ use super::fs_ops::{
     to_registry_resolved_config, validate_resolved_config, validate_revision,
     validate_source_directory, write_bytes, write_json,
 };
-use super::root::{build_registry_root_payload, create_registry_root_envelope};
+use super::root::{
+    build_registry_root_payload, create_registry_root_envelope, registry_root_signing_input,
+};
+use super::root_verify::parse_registry_root_envelope;
 use super::*;
 use chrono::{DateTime, SecondsFormat, Utc};
 
@@ -16,6 +19,12 @@ pub struct ConfigRegistryPublisher {
     compiled_dir: PathBuf,
     staging_dir: PathBuf,
     current_path: PathBuf,
+}
+
+#[derive(Debug)]
+struct CommittedRevision {
+    manifest_sha256: String,
+    registry_root_sha256: Option<String>,
 }
 
 impl ConfigRegistryPublisher {
@@ -85,24 +94,17 @@ impl ConfigRegistryPublisher {
         validate_revision(&revision_id)?;
 
         let compiled_path = self.compiled_dir.join(&revision_id);
-        if compiled_path.exists() {
-            return Err(InvalidConfigError {
-                message: format!("Registry revision already exists: {revision_id}"),
-            }
-            .into());
-        }
-
         let stage_path = staging_attempt_path(&self.staging_dir, &revision_id, published_at);
 
         let publish_result = (|| -> LlmixResult<PublishedRevision> {
-            let manifest = self.build_staged_snapshot(
+            let manifest = self.build_staged_revision(
                 &stage_path,
                 &presets,
                 &revision_id,
                 &published_at_text,
                 &options.mda_options,
             )?;
-            self.verify_staged_snapshot(&stage_path, &manifest)?;
+            self.verify_staged_revision(&stage_path, &manifest)?;
             let manifest_path = stage_path.join("manifest.json");
             let manifest_sha256 = sha256_file(&manifest_path)?;
             let registry_root_sha256 = self.write_registry_root_if_requested(
@@ -112,35 +114,37 @@ impl ConfigRegistryPublisher {
                 options.registry_root.as_ref(),
             )?;
 
-            fs::create_dir_all(&self.compiled_dir)?;
-            fs::create_dir_all(&self.staging_dir)?;
-            fs::rename(&stage_path, &compiled_path)?;
-            fsync_dir(&self.compiled_dir);
+            let committed = self.commit_revision(
+                &stage_path,
+                &compiled_path,
+                &manifest,
+                manifest_sha256,
+                registry_root_sha256,
+                options.registry_root.as_ref(),
+            )?;
 
             if options.activate {
                 let pointer = CurrentPointer {
                     revision: revision_id.clone(),
-                    manifest_sha256: Some(manifest_sha256.clone()),
+                    manifest_sha256: Some(committed.manifest_sha256.clone()),
                 };
-                if let Err(error) = atomic_write_json(
+                atomic_write_json(
                     &self.current_path,
                     &serde_json::to_value(pointer).map_err(LlmixError::from)?,
-                ) {
-                    let _ = fs::remove_dir_all(&compiled_path);
-                    fsync_dir(&self.compiled_dir);
-                    return Err(error);
-                }
+                )?;
             }
 
+            let registry_root_path = committed
+                .registry_root_sha256
+                .as_ref()
+                .map(|_| compiled_path.join(REGISTRY_ROOT_FILENAME));
             Ok(PublishedRevision {
                 revision: revision_id.clone(),
                 compiled_path: compiled_path.clone(),
                 manifest_path: compiled_path.join("manifest.json"),
-                manifest_sha256,
-                registry_root_path: registry_root_sha256
-                    .as_ref()
-                    .map(|_| compiled_path.join(REGISTRY_ROOT_FILENAME)),
-                registry_root_sha256,
+                manifest_sha256: committed.manifest_sha256,
+                registry_root_path,
+                registry_root_sha256: committed.registry_root_sha256,
                 activated: options.activate,
                 preset_ids: manifest.presets.keys().cloned().collect(),
             })
@@ -151,6 +155,168 @@ impl ConfigRegistryPublisher {
         }
 
         publish_result
+    }
+
+    fn commit_revision(
+        &self,
+        stage_path: &Path,
+        compiled_path: &Path,
+        expected_manifest: &RegistryManifest,
+        manifest_sha256: String,
+        registry_root_sha256: Option<String>,
+        registry_root_options: Option<&RegistryRootSigningOptions<'_>>,
+    ) -> LlmixResult<CommittedRevision> {
+        fs::create_dir_all(&self.compiled_dir)?;
+        fs::create_dir_all(&self.staging_dir)?;
+        match fs::rename(stage_path, compiled_path) {
+            Ok(()) => {
+                fsync_dir(&self.compiled_dir);
+                Ok(CommittedRevision {
+                    manifest_sha256,
+                    registry_root_sha256,
+                })
+            }
+            Err(_) if compiled_path.exists() => {
+                let committed = self.load_matching_existing_revision(
+                    compiled_path,
+                    expected_manifest,
+                    registry_root_sha256.as_deref(),
+                    registry_root_options,
+                )?;
+                if stage_path.exists() {
+                    let _ = fs::remove_dir_all(stage_path);
+                }
+                Ok(committed)
+            }
+            Err(error) => Err(error.into()),
+        }
+    }
+
+    fn load_matching_existing_revision(
+        &self,
+        compiled_path: &Path,
+        expected_manifest: &RegistryManifest,
+        registry_root_sha256: Option<&str>,
+        registry_root_options: Option<&RegistryRootSigningOptions<'_>>,
+    ) -> LlmixResult<CommittedRevision> {
+        let manifest_path = compiled_path.join("manifest.json");
+        let existing_manifest_value = Value::Object(read_json_object(&manifest_path)?);
+        let existing_manifest: RegistryManifest = serde_json::from_value(existing_manifest_value)
+            .map_err(|error| InvalidConfigError {
+            message: format!(
+                "Invalid Config Registry manifest {}: {error}",
+                manifest_path.display()
+            ),
+        })?;
+        self.verify_staged_revision(compiled_path, &existing_manifest)?;
+
+        if existing_manifest.revision != expected_manifest.revision
+            || existing_manifest.schema_version != expected_manifest.schema_version
+            || existing_manifest.presets != expected_manifest.presets
+        {
+            return Err(InvalidConfigError {
+                message: format!(
+                    "Registry revision already exists with different contents: {}",
+                    expected_manifest.revision
+                ),
+            }
+            .into());
+        }
+
+        let existing_manifest_sha256 = sha256_file(&manifest_path)?;
+        let root_path = compiled_path.join(REGISTRY_ROOT_FILENAME);
+        let existing_registry_root_sha256 = if root_path.exists() {
+            Some(sha256_file(&root_path)?)
+        } else {
+            None
+        };
+        // Signed roots include publish-time material; same-revision retries must
+        // reuse the already committed root once the manifest contents match.
+        if registry_root_sha256.is_some() {
+            match existing_registry_root_sha256.as_deref() {
+                Some(_) => {
+                    let Some(registry_root_options) = registry_root_options else {
+                        return Err(InvalidConfigError {
+                            message:
+                                "Registry revision already exists but no registry root signer is available"
+                                    .to_string(),
+                        }
+                        .into());
+                    };
+                    self.verify_existing_registry_root(
+                        &root_path,
+                        &existing_manifest,
+                        &existing_manifest_sha256,
+                        registry_root_options,
+                    )?
+                }
+                None => {
+                    return Err(InvalidConfigError {
+                        message:
+                            "Registry revision already exists without the requested registry root"
+                                .to_string(),
+                    }
+                    .into())
+                }
+            }
+        }
+
+        Ok(CommittedRevision {
+            manifest_sha256: existing_manifest_sha256,
+            registry_root_sha256: existing_registry_root_sha256,
+        })
+    }
+
+    fn verify_existing_registry_root(
+        &self,
+        root_path: &Path,
+        manifest: &RegistryManifest,
+        manifest_sha256: &str,
+        registry_root_options: &RegistryRootSigningOptions<'_>,
+    ) -> LlmixResult<()> {
+        let envelope = parse_registry_root_envelope(root_path)?;
+        let signing_input = registry_root_signing_input(envelope.payload.clone())?;
+        if signing_input.payload_sha256 != envelope.payload_sha256
+            || signing_input.integrity.digest != envelope.integrity.digest
+        {
+            return Err(InvalidConfigError {
+                message: "Registry root payload digest mismatch".to_string(),
+            }
+            .into());
+        }
+        for signature in &envelope.signatures {
+            if signature.payload_digest != signing_input.integrity.digest {
+                return Err(InvalidConfigError {
+                    message:
+                        "Registry revision already exists with a registry root signature payload mismatch"
+                            .to_string(),
+                }
+                .into());
+            }
+        }
+
+        let expected_payload = build_registry_root_payload(manifest, manifest_sha256)?;
+        if envelope.payload != expected_payload {
+            return Err(InvalidConfigError {
+                message:
+                    "Registry revision already exists with a registry root that does not match the committed manifest"
+                        .to_string(),
+            }
+            .into());
+        }
+        let expected_envelope =
+            create_registry_root_envelope(expected_payload, registry_root_options)?;
+        if envelope.integrity != expected_envelope.integrity
+            || envelope.payload_sha256 != expected_envelope.payload_sha256
+            || envelope.signatures != expected_envelope.signatures
+        {
+            return Err(InvalidConfigError {
+                message: "Registry revision already exists with a registry root signature mismatch"
+                    .to_string(),
+            }
+            .into());
+        }
+        Ok(())
     }
 
     fn write_registry_root_if_requested(
@@ -275,7 +441,7 @@ impl ConfigRegistryPublisher {
         Ok(format!("r{published_at}_{}", &hash[..8]))
     }
 
-    fn build_staged_snapshot(
+    fn build_staged_revision(
         &self,
         stage_path: &Path,
         presets: &[PresetSource],
@@ -325,7 +491,7 @@ impl ConfigRegistryPublisher {
         Ok(manifest)
     }
 
-    fn verify_staged_snapshot(
+    fn verify_staged_revision(
         &self,
         stage_path: &Path,
         manifest: &RegistryManifest,

--- a/packages/llmix/rust/src/config_registry/publisher.rs
+++ b/packages/llmix/rust/src/config_registry/publisher.rs
@@ -7,6 +7,7 @@ use super::fs_ops::{
 };
 use super::root::{
     build_registry_root_payload, create_registry_root_envelope, registry_root_signing_input,
+    required_signature_count,
 };
 use super::root_verify::parse_registry_root_envelope;
 use super::*;
@@ -294,6 +295,16 @@ impl ConfigRegistryPublisher {
                 .into());
             }
         }
+        let required_signatures = required_signature_count(registry_root_options.min_signatures)?;
+        if envelope.signatures.len() < required_signatures {
+            return Err(InvalidConfigError {
+                message: format!(
+                    "Registry revision already exists with {} registry root signatures; expected at least {required_signatures}",
+                    envelope.signatures.len()
+                ),
+            }
+            .into());
+        }
 
         let expected_payload = build_registry_root_payload(manifest, manifest_sha256)?;
         if envelope.payload != expected_payload {
@@ -301,18 +312,6 @@ impl ConfigRegistryPublisher {
                 message:
                     "Registry revision already exists with a registry root that does not match the committed manifest"
                         .to_string(),
-            }
-            .into());
-        }
-        let expected_envelope =
-            create_registry_root_envelope(expected_payload, registry_root_options)?;
-        if envelope.integrity != expected_envelope.integrity
-            || envelope.payload_sha256 != expected_envelope.payload_sha256
-            || envelope.signatures != expected_envelope.signatures
-        {
-            return Err(InvalidConfigError {
-                message: "Registry revision already exists with a registry root signature mismatch"
-                    .to_string(),
             }
             .into());
         }

--- a/packages/llmix/rust/src/config_registry/root_verify.rs
+++ b/packages/llmix/rust/src/config_registry/root_verify.rs
@@ -34,7 +34,7 @@ pub(super) fn verify_signed_registry_root_if_needed(
     )
 }
 
-fn parse_registry_root_envelope(path: &Path) -> LlmixResult<RegistryRootEnvelope> {
+pub(super) fn parse_registry_root_envelope(path: &Path) -> LlmixResult<RegistryRootEnvelope> {
     let value = Value::Object(read_json_object(path)?);
     let envelope: RegistryRootEnvelope =
         serde_json::from_value(value).map_err(|error| InvalidConfigError {

--- a/packages/llmix/rust/tests/parity_config.rs
+++ b/packages/llmix/rust/tests/parity_config.rs
@@ -30,7 +30,7 @@ fn load_config_projects_mda_fixture_shape() {
 }
 
 #[test]
-fn load_config_preset_uses_mda_authoring_path() {
+fn load_config_preset_uses_mda_source_path() {
     let config = load_config_preset("sample_preset", fixture_dir()).expect("preset should load");
 
     assert_eq!(config["provider"], "openai");

--- a/packages/llmix/rust/tests/unit_config_registry.rs
+++ b/packages/llmix/rust/tests/unit_config_registry.rs
@@ -34,7 +34,7 @@ fn mda_source(frontmatter: &str) -> String {
     format!("---\n{}\n---\n# preset\n", frontmatter.trim())
 }
 
-fn write_authoring_preset(
+fn write_source_preset(
     root: &Path,
     module_name: &str,
     preset_name: &str,
@@ -145,7 +145,7 @@ fn signed_registry_open_options() -> ConfigRegistryOpenOptions {
 fn publish_creates_active_revision_and_manager_reads_canonical_resolved_json() {
     let temp_root = unique_temp_dir("llmix-config-registry-publish");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(
+    write_source_preset(
         &root,
         "search",
         "summary",
@@ -174,7 +174,9 @@ fn publish_creates_active_revision_and_manager_reads_canonical_resolved_json() {
     assert_eq!(manager.current_path(), root.join("current.json").as_path());
     assert_eq!(manager.compiled_dir(), root.join("compiled").as_path());
     assert_eq!(
-        manager.available_presets(),
+        manager
+            .available_presets()
+            .expect("available presets should list"),
         vec!["search/summary".to_string()]
     );
     assert!(root
@@ -202,7 +204,7 @@ fn publish_creates_active_revision_and_manager_reads_canonical_resolved_json() {
 fn signed_registry_root_publish_and_open_use_public_options() {
     let temp_root = unique_temp_dir("llmix-config-registry-signed-root");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(
+    write_source_preset(
         &root,
         "search",
         "summary",
@@ -232,10 +234,199 @@ fn signed_registry_root_publish_and_open_use_public_options() {
 }
 
 #[test]
+fn signed_registry_root_refresh_fails_closed_when_trust_anchor_stays_pinned() {
+    let temp_root = unique_temp_dir("llmix-config-registry-signed-refresh-fail-closed");
+    let root = temp_root.join("config/llm");
+    write_source_preset(
+        &root,
+        "search",
+        "summary",
+        Some(("gpt-4.1-mini", "medium", 256, "openai")),
+    );
+
+    let signer = TestRegistryRootSigner;
+    let publisher = ConfigRegistryPublisher::new(&root).expect("publisher should open");
+    let first = publisher
+        .publish_with_registry_options(&signed_registry_publish_options("signed-1", &signer))
+        .expect("first signed publish should succeed");
+    let mut open_options = signed_registry_open_options();
+    open_options
+        .signed_root
+        .as_mut()
+        .expect("signed root options should exist")
+        .expected_root_digest = first.registry_root_sha256.clone();
+    let mut manager = ConfigRegistryManager::open_with_options(&root, open_options)
+        .expect("signed registry should open");
+
+    write_source_preset(
+        &root,
+        "search",
+        "summary",
+        Some(("gpt-5-mini", "high", 2048, "openai")),
+    );
+    let second = publisher
+        .publish_with_registry_options(&signed_registry_publish_options("signed-2", &signer))
+        .expect("second signed publish should succeed");
+
+    assert_ne!(second.registry_root_sha256, first.registry_root_sha256);
+    let error = manager
+        .available_presets()
+        .expect_err("signed refresh should fail closed when pinned digest changes");
+    assert!(
+        error.to_string().contains("expected_root_digest"),
+        "unexpected error: {error}"
+    );
+    assert_eq!(manager.active_revision(), "signed-1");
+    assert!(manager.last_reload_error().is_some());
+}
+
+#[test]
+fn signed_activation_failure_reuses_committed_registry_root_on_retry() {
+    let temp_root = unique_temp_dir("llmix-config-registry-signed-activation-retry");
+    let root = temp_root.join("config/llm");
+    write_source_preset(
+        &root,
+        "search",
+        "summary",
+        Some(("gpt-4.1-mini", "medium", 256, "openai")),
+    );
+    fs::create_dir_all(root.join("current.json")).expect("current path directory should exist");
+
+    let signer = TestRegistryRootSigner;
+    let publisher = ConfigRegistryPublisher::new(&root).expect("publisher should open");
+    let error = publisher
+        .publish_with_registry_options(&signed_registry_publish_options("signed-1", &signer))
+        .expect_err("activation should fail when current.json is a directory");
+
+    assert!(matches!(error, LlmixError::Io(_)));
+    let root_path = root.join("compiled/signed-1/registry-root.json");
+    let committed_root_bytes = fs::read(&root_path).expect("registry root should exist");
+
+    fs::remove_dir_all(root.join("current.json"))
+        .expect("current path directory should be removed");
+    let published = publisher
+        .publish_with_registry_options(&signed_registry_publish_options("signed-1", &signer))
+        .expect("same signed revision should reuse the committed registry root");
+    let mut open_options = signed_registry_open_options();
+    open_options
+        .signed_root
+        .as_mut()
+        .expect("signed root options should exist")
+        .expected_root_digest = published.registry_root_sha256.clone();
+    let mut manager = ConfigRegistryManager::open_with_options(&root, open_options)
+        .expect("signed registry should open");
+    let config = manager
+        .get_preset("search", "summary")
+        .expect("preset should load");
+
+    assert_eq!(
+        published.registry_root_path.as_deref(),
+        Some(root_path.as_path())
+    );
+    assert!(published.registry_root_sha256.is_some());
+    assert_eq!(
+        fs::read(&root_path).expect("registry root should remain readable"),
+        committed_root_bytes
+    );
+    assert_eq!(manager.active_revision(), "signed-1");
+    assert_eq!(config["model"], json!("gpt-4.1-mini"));
+}
+
+#[test]
+fn signed_activation_retry_rejects_corrupted_committed_registry_root() {
+    let temp_root = unique_temp_dir("llmix-config-registry-signed-retry-tampered-root");
+    let root = temp_root.join("config/llm");
+    write_source_preset(
+        &root,
+        "search",
+        "summary",
+        Some(("gpt-4.1-mini", "medium", 256, "openai")),
+    );
+    fs::create_dir_all(root.join("current.json")).expect("current path directory should exist");
+
+    let signer = TestRegistryRootSigner;
+    let publisher = ConfigRegistryPublisher::new(&root).expect("publisher should open");
+    let error = publisher
+        .publish_with_registry_options(&signed_registry_publish_options("signed-1", &signer))
+        .expect_err("activation should fail when current.json is a directory");
+    assert!(matches!(error, LlmixError::Io(_)));
+
+    let root_path = root.join("compiled/signed-1/registry-root.json");
+    let mut envelope: Value = serde_json::from_str(
+        &fs::read_to_string(&root_path).expect("registry root should be readable"),
+    )
+    .expect("registry root should parse");
+    envelope["payload"]["files"] = json!([]);
+    fs::write(
+        &root_path,
+        serde_json::to_string(&envelope).expect("tampered root should serialize"),
+    )
+    .expect("registry root should be overwritten");
+
+    fs::remove_dir_all(root.join("current.json"))
+        .expect("current path directory should be removed");
+    let error = publisher
+        .publish_with_registry_options(&signed_registry_publish_options("signed-1", &signer))
+        .expect_err("tampered committed registry root should block retry");
+
+    assert!(matches!(error, LlmixError::InvalidConfig(_)));
+    assert!(
+        error.to_string().contains("Registry root"),
+        "unexpected error: {error}"
+    );
+    assert!(!root.join("current.json").exists());
+}
+
+#[test]
+fn signed_activation_retry_rejects_corrupted_committed_registry_root_signature() {
+    let temp_root = unique_temp_dir("llmix-config-registry-signed-retry-tampered-signature");
+    let root = temp_root.join("config/llm");
+    write_source_preset(
+        &root,
+        "search",
+        "summary",
+        Some(("gpt-4.1-mini", "medium", 256, "openai")),
+    );
+    fs::create_dir_all(root.join("current.json")).expect("current path directory should exist");
+
+    let signer = TestRegistryRootSigner;
+    let publisher = ConfigRegistryPublisher::new(&root).expect("publisher should open");
+    let error = publisher
+        .publish_with_registry_options(&signed_registry_publish_options("signed-1", &signer))
+        .expect_err("activation should fail when current.json is a directory");
+    assert!(matches!(error, LlmixError::Io(_)));
+
+    let root_path = root.join("compiled/signed-1/registry-root.json");
+    let mut envelope: Value = serde_json::from_str(
+        &fs::read_to_string(&root_path).expect("registry root should be readable"),
+    )
+    .expect("registry root should parse");
+    envelope["signatures"][0]["signature"] = json!("TAMPERED_SIGNATURE");
+    fs::write(
+        &root_path,
+        serde_json::to_string(&envelope).expect("tampered root should serialize"),
+    )
+    .expect("registry root should be overwritten");
+
+    fs::remove_dir_all(root.join("current.json"))
+        .expect("current path directory should be removed");
+    let error = publisher
+        .publish_with_registry_options(&signed_registry_publish_options("signed-1", &signer))
+        .expect_err("tampered committed registry root signature should block retry");
+
+    assert!(matches!(error, LlmixError::InvalidConfig(_)));
+    assert!(
+        error.to_string().contains("signature mismatch"),
+        "unexpected error: {error}"
+    );
+    assert!(!root.join("current.json").exists());
+}
+
+#[test]
 fn signed_registry_root_opens_from_cli_trust_manifest_schema() {
     let temp_root = unique_temp_dir("llmix-config-registry-trust-manifest");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(&root, "search", "summary", None);
+    write_source_preset(&root, "search", "summary", None);
 
     let signer = TestRegistryRootSigner;
     let publisher = ConfigRegistryPublisher::new(&root).expect("publisher should open");
@@ -362,7 +553,7 @@ fn signed_registry_root_opens_from_cli_trust_manifest_schema() {
 fn signed_registry_root_rejects_tampered_registry_root_payload() {
     let temp_root = unique_temp_dir("llmix-config-registry-signed-root-tamper");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(&root, "search", "summary", None);
+    write_source_preset(&root, "search", "summary", None);
 
     let signer = TestRegistryRootSigner;
     let publisher = ConfigRegistryPublisher::new(&root).expect("publisher should open");
@@ -404,7 +595,7 @@ fn signed_registry_root_rejects_tampered_registry_root_payload() {
 fn signed_registry_root_rejects_current_binding_digest_mismatch_during_parse() {
     let temp_root = unique_temp_dir("llmix-config-registry-current-binding-tamper");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(&root, "search", "summary", None);
+    write_source_preset(&root, "search", "summary", None);
 
     let signer = TestRegistryRootSigner;
     let publisher = ConfigRegistryPublisher::new(&root).expect("publisher should open");
@@ -440,7 +631,7 @@ fn signed_registry_root_rejects_current_binding_digest_mismatch_during_parse() {
 fn publish_uses_unique_staging_dir_for_explicit_revision() {
     let temp_root = unique_temp_dir("llmix-config-registry-unique-stage");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(
+    write_source_preset(
         &root,
         "search",
         "summary",
@@ -462,10 +653,66 @@ fn publish_uses_unique_staging_dir_for_explicit_revision() {
 }
 
 #[test]
+fn publish_same_revision_from_same_source_is_idempotent() {
+    let temp_root = unique_temp_dir("llmix-config-registry-idempotent-revision");
+    let root = temp_root.join("config/llm");
+    write_source_preset(&root, "search", "summary", None);
+
+    let publisher = ConfigRegistryPublisher::new(&root).expect("publisher should open");
+    let first = publisher
+        .publish_with_options(Some("manual"), false)
+        .expect("first publish should succeed");
+    let second = publisher
+        .publish_with_options(Some("manual"), true)
+        .expect("second publish should reuse the compiled revision");
+    let mut manager = ConfigRegistryManager::open(&root).expect("manager should open");
+    let config = manager
+        .get_preset("search", "summary")
+        .expect("preset should load");
+
+    assert_eq!(first.manifest_sha256, second.manifest_sha256);
+    assert_eq!(second.revision, "manual");
+    assert!(second.activated);
+    assert_eq!(manager.active_revision(), "manual");
+    assert_eq!(config["model"], json!("gpt-4.1-mini"));
+}
+
+#[test]
+fn publish_same_revision_with_different_source_fails() {
+    let temp_root = unique_temp_dir("llmix-config-registry-different-revision");
+    let root = temp_root.join("config/llm");
+    write_source_preset(
+        &root,
+        "search",
+        "summary",
+        Some(("gpt-4.1-mini", "medium", 256, "openai")),
+    );
+
+    let publisher = ConfigRegistryPublisher::new(&root).expect("publisher should open");
+    publisher
+        .publish_with_options(Some("manual"), false)
+        .expect("first publish should succeed");
+    write_source_preset(
+        &root,
+        "search",
+        "summary",
+        Some(("gpt-5-mini", "high", 2048, "openai")),
+    );
+
+    let error = publisher
+        .publish_with_options(Some("manual"), false)
+        .expect_err("changed source should not reuse an existing revision");
+    assert!(
+        error.to_string().contains("different contents"),
+        "unexpected error: {error}"
+    );
+}
+
+#[test]
 fn manager_reloads_after_current_revision_changes() {
     let temp_root = unique_temp_dir("llmix-config-registry-reload");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(
+    write_source_preset(
         &root,
         "search",
         "summary",
@@ -476,7 +723,7 @@ fn manager_reloads_after_current_revision_changes() {
     let first = publisher.publish().expect("first publish should succeed");
     let mut manager = ConfigRegistryManager::open(&root).expect("manager should open");
 
-    write_authoring_preset(
+    write_source_preset(
         &root,
         "search",
         "summary",
@@ -498,10 +745,10 @@ fn manager_reloads_after_current_revision_changes() {
 }
 
 #[test]
-fn manager_rolls_back_when_current_revision_points_to_older_snapshot() {
+fn manager_rolls_back_when_current_revision_points_to_older_revision() {
     let temp_root = unique_temp_dir("llmix-config-registry-rollback");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(
+    write_source_preset(
         &root,
         "search",
         "summary",
@@ -512,7 +759,7 @@ fn manager_rolls_back_when_current_revision_points_to_older_snapshot() {
     let first = publisher.publish().expect("first publish should succeed");
     let mut manager = ConfigRegistryManager::open(&root).expect("manager should open");
 
-    write_authoring_preset(
+    write_source_preset(
         &root,
         "search",
         "summary",
@@ -545,10 +792,10 @@ fn manager_rolls_back_when_current_revision_points_to_older_snapshot() {
 }
 
 #[test]
-fn manager_ignores_authoring_edits_until_a_new_revision_is_published() {
-    let temp_root = unique_temp_dir("llmix-config-registry-authoring-edits");
+fn manager_ignores_source_edits_until_a_new_revision_is_published() {
+    let temp_root = unique_temp_dir("llmix-config-registry-source-edits");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(
+    write_source_preset(
         &root,
         "search",
         "summary",
@@ -559,7 +806,7 @@ fn manager_ignores_authoring_edits_until_a_new_revision_is_published() {
     let published = publisher.publish().expect("publish should succeed");
     let mut manager = ConfigRegistryManager::open(&root).expect("manager should open");
 
-    write_authoring_preset(
+    write_source_preset(
         &root,
         "search",
         "summary",
@@ -604,7 +851,7 @@ fn manager_fails_fast_with_malformed_current_pointer() {
 fn manager_keeps_last_known_good_config_when_pointer_changes_to_missing_revision() {
     let temp_root = unique_temp_dir("llmix-config-registry-missing-revision");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(
+    write_source_preset(
         &root,
         "search",
         "summary",
@@ -636,10 +883,10 @@ fn manager_keeps_last_known_good_config_when_pointer_changes_to_missing_revision
 }
 
 #[test]
-fn manager_rejects_a_tampered_resolved_snapshot_on_startup() {
+fn manager_rejects_a_tampered_resolved_revision_on_startup() {
     let temp_root = unique_temp_dir("llmix-config-registry-tampered");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(
+    write_source_preset(
         &root,
         "search",
         "summary",
@@ -665,7 +912,7 @@ fn manager_rejects_a_tampered_resolved_snapshot_on_startup() {
     )
     .expect("resolved json should be overwritten");
 
-    let error = ConfigRegistryManager::open(&root).expect_err("tampered snapshot should fail");
+    let error = ConfigRegistryManager::open(&root).expect_err("tampered revision should fail");
     assert!(matches!(
         error,
         LlmixError::InvalidConfig(InvalidConfigError { .. })
@@ -673,10 +920,10 @@ fn manager_rejects_a_tampered_resolved_snapshot_on_startup() {
 }
 
 #[test]
-fn manager_rejects_a_tampered_authoring_snapshot_on_startup() {
-    let temp_root = unique_temp_dir("llmix-config-registry-authoring-tampered");
+fn manager_rejects_a_tampered_source_revision_on_startup() {
+    let temp_root = unique_temp_dir("llmix-config-registry-source-tampered");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(&root, "search", "summary", None);
+    write_source_preset(&root, "search", "summary", None);
 
     let published = ConfigRegistryPublisher::new(&root)
         .expect("publisher should open")
@@ -687,9 +934,9 @@ fn manager_rejects_a_tampered_authoring_snapshot_on_startup() {
         .join(&published.revision)
         .join("source/search/summary.mda");
     fs::write(&source_path, "---\nname: tampered\n---\n")
-        .expect("authoring artifact should be overwritten");
+        .expect("source artifact should be overwritten");
 
-    let error = ConfigRegistryManager::open(&root).expect_err("tampered snapshot should fail");
+    let error = ConfigRegistryManager::open(&root).expect_err("tampered revision should fail");
     assert!(matches!(
         error,
         LlmixError::InvalidConfig(InvalidConfigError { .. })
@@ -700,7 +947,7 @@ fn manager_rejects_a_tampered_authoring_snapshot_on_startup() {
 fn manager_rejects_manifest_with_empty_artifact_paths_before_opening_them() {
     let temp_root = unique_temp_dir("llmix-config-registry-empty-manifest-path");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(&root, "search", "summary", None);
+    write_source_preset(&root, "search", "summary", None);
 
     let published = ConfigRegistryPublisher::new(&root)
         .expect("publisher should open")
@@ -731,7 +978,7 @@ fn manager_rejects_manifest_with_empty_artifact_paths_before_opening_them() {
 fn publish_failure_leaves_active_revision_unchanged() {
     let temp_root = unique_temp_dir("llmix-config-registry-publish-failure");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(
+    write_source_preset(
         &root,
         "search",
         "summary",
@@ -747,7 +994,7 @@ fn publish_failure_leaves_active_revision_unchanged() {
 
     let error = publisher
         .publish()
-        .expect_err("publishing invalid authoring MDA should fail");
+        .expect_err("publishing invalid source MDA should fail");
     assert!(matches!(error, LlmixError::InvalidConfig(_)));
 
     let pointer: Value = serde_json::from_str(
@@ -771,7 +1018,7 @@ fn publish_failure_leaves_active_revision_unchanged() {
 fn publish_with_mda_options_uses_mda_verification() {
     let temp_root = unique_temp_dir("llmix-config-registry-verification-options");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(&root, "search", "summary", None);
+    write_source_preset(&root, "search", "summary", None);
 
     let publisher = ConfigRegistryPublisher::new(&root).expect("publisher should open");
     let error = publisher
@@ -797,15 +1044,15 @@ fn publish_with_mda_options_uses_mda_verification() {
     );
     assert!(
         !root.join("compiled/manual").exists(),
-        "failed publish should not keep a snapshot"
+        "failed publish should not keep a revision"
     );
 }
 
 #[test]
-fn activation_failure_removes_new_snapshot_so_revision_can_retry() {
+fn activation_failure_keeps_compiled_revision_so_current_can_retry() {
     let temp_root = unique_temp_dir("llmix-config-registry-activation-failure");
     let root = temp_root.join("config/llm");
-    write_authoring_preset(
+    write_source_preset(
         &root,
         "search",
         "summary",
@@ -820,8 +1067,8 @@ fn activation_failure_removes_new_snapshot_so_revision_can_retry() {
 
     assert!(matches!(error, LlmixError::Io(_)));
     assert!(
-        !root.join("compiled/manual").exists(),
-        "failed activation should remove the newly renamed snapshot"
+        root.join("compiled/manual/manifest.json").is_file(),
+        "failed activation should keep the compiled revision"
     );
 
     fs::remove_dir_all(root.join("current.json"))
@@ -829,12 +1076,19 @@ fn activation_failure_removes_new_snapshot_so_revision_can_retry() {
     let published = publisher
         .publish_with_options(Some("manual"), true)
         .expect("same revision should publish after cleanup");
+    let mut manager = ConfigRegistryManager::open(&root).expect("manager should open");
+    let config = manager
+        .get_preset("search", "summary")
+        .expect("preset should load");
+
     assert_eq!(published.revision, "manual");
     assert!(published.activated);
+    assert_eq!(manager.active_revision(), "manual");
+    assert_eq!(config["model"], json!("gpt-4.1-mini"));
 }
 
 #[test]
-fn publisher_rejects_legacy_yaml_authoring_files() {
+fn publisher_rejects_legacy_yaml_source_files() {
     let temp_root = unique_temp_dir("llmix-config-registry-legacy-yaml");
     let root = temp_root.join("config/llm");
     write_file(
@@ -845,7 +1099,7 @@ fn publisher_rejects_legacy_yaml_authoring_files() {
     let error = ConfigRegistryPublisher::new(&root)
         .expect("publisher should open")
         .publish()
-        .expect_err("legacy YAML authoring should fail");
+        .expect_err("legacy YAML source should fail");
 
     assert!(matches!(error, LlmixError::InvalidConfig(_)));
     assert!(
@@ -858,7 +1112,7 @@ fn publisher_rejects_legacy_yaml_authoring_files() {
 
 #[cfg(unix)]
 #[test]
-fn publisher_rejects_symlinked_authoring_modules() {
+fn publisher_rejects_symlinked_source_modules() {
     let temp_root = unique_temp_dir("llmix-config-registry-module-symlink");
     let root = temp_root.join("config/llm");
     let outside_module = temp_root.join("outside-module");
@@ -875,14 +1129,14 @@ metadata:
 "#,
         ),
     );
-    fs::create_dir_all(root.join("source")).expect("authoring dir should exist");
+    fs::create_dir_all(root.join("source")).expect("source dir should exist");
     std::os::unix::fs::symlink(&outside_module, root.join("source/search"))
         .expect("module symlink should be created");
 
     let error = ConfigRegistryPublisher::new(&root)
         .expect("publisher should open")
         .publish()
-        .expect_err("symlinked authoring module should fail");
+        .expect_err("symlinked source module should fail");
 
     assert!(matches!(error, LlmixError::InvalidConfig(_)));
     assert!(
@@ -893,7 +1147,7 @@ metadata:
 
 #[cfg(unix)]
 #[test]
-fn publisher_rejects_symlinked_authoring_presets() {
+fn publisher_rejects_symlinked_source_presets() {
     let temp_root = unique_temp_dir("llmix-config-registry-preset-symlink");
     let root = temp_root.join("config/llm");
     let outside_preset = temp_root.join("outside-summary.mda");
@@ -917,7 +1171,7 @@ metadata:
     let error = ConfigRegistryPublisher::new(&root)
         .expect("publisher should open")
         .publish()
-        .expect_err("symlinked authoring preset should fail");
+        .expect_err("symlinked source preset should fail");
 
     assert!(matches!(error, LlmixError::InvalidConfig(_)));
     assert!(

--- a/packages/llmix/rust/tests/unit_config_registry.rs
+++ b/packages/llmix/rust/tests/unit_config_registry.rs
@@ -7,6 +7,7 @@ use llmix_rs::{
     RegistryRootSigningOptions, RegistryRootVerificationOptions, TrustPolicy, TrustedSigner,
 };
 use serde_json::{json, Value};
+use std::cell::Cell;
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -80,6 +81,38 @@ impl RegistryRootSigner for TestRegistryRootSigner {
             payload_digest: input.integrity.digest.clone(),
             algorithm: "ed25519".to_string(),
             signature: "TEST_SIGNATURE".to_string(),
+            rekor_log_id: None,
+            rekor_log_index: None,
+            payload_type: Some(input.payload_type.clone()),
+        }])
+    }
+}
+
+struct NonDeterministicRegistryRootSigner {
+    counter: Cell<usize>,
+}
+
+impl NonDeterministicRegistryRootSigner {
+    fn new() -> Self {
+        Self {
+            counter: Cell::new(0),
+        }
+    }
+}
+
+impl RegistryRootSigner for NonDeterministicRegistryRootSigner {
+    fn sign_registry_root(
+        &self,
+        input: &RegistryRootSigningInput,
+    ) -> LlmixResult<Vec<RegistryRootSignature>> {
+        let next = self.counter.get() + 1;
+        self.counter.set(next);
+        Ok(vec![RegistryRootSignature {
+            signer: "did-web:tools.example.com".to_string(),
+            key_id: "did:web:tools.example.com#key-1".to_string(),
+            payload_digest: input.integrity.digest.clone(),
+            algorithm: "ed25519".to_string(),
+            signature: format!("TEST_SIGNATURE_{next}"),
             rekor_log_id: None,
             rekor_log_index: None,
             payload_type: Some(input.payload_type.clone()),
@@ -292,7 +325,7 @@ fn signed_activation_failure_reuses_committed_registry_root_on_retry() {
     );
     fs::create_dir_all(root.join("current.json")).expect("current path directory should exist");
 
-    let signer = TestRegistryRootSigner;
+    let signer = NonDeterministicRegistryRootSigner::new();
     let publisher = ConfigRegistryPublisher::new(&root).expect("publisher should open");
     let error = publisher
         .publish_with_registry_options(&signed_registry_publish_options("signed-1", &signer))
@@ -378,7 +411,7 @@ fn signed_activation_retry_rejects_corrupted_committed_registry_root() {
 }
 
 #[test]
-fn signed_activation_retry_rejects_corrupted_committed_registry_root_signature() {
+fn signed_activation_retry_rejects_corrupted_committed_registry_root_signature_digest() {
     let temp_root = unique_temp_dir("llmix-config-registry-signed-retry-tampered-signature");
     let root = temp_root.join("config/llm");
     write_source_preset(
@@ -401,7 +434,7 @@ fn signed_activation_retry_rejects_corrupted_committed_registry_root_signature()
         &fs::read_to_string(&root_path).expect("registry root should be readable"),
     )
     .expect("registry root should parse");
-    envelope["signatures"][0]["signature"] = json!("TAMPERED_SIGNATURE");
+    envelope["signatures"][0]["payload-digest"] = json!(format!("sha256:{}", "0".repeat(64)));
     fs::write(
         &root_path,
         serde_json::to_string(&envelope).expect("tampered root should serialize"),
@@ -416,7 +449,7 @@ fn signed_activation_retry_rejects_corrupted_committed_registry_root_signature()
 
     assert!(matches!(error, LlmixError::InvalidConfig(_)));
     assert!(
-        error.to_string().contains("signature mismatch"),
+        error.to_string().contains("signature payload mismatch"),
         "unexpected error: {error}"
     );
     assert!(!root.join("current.json").exists());

--- a/packages/llmix/rust/tests/unit_config_registry.rs
+++ b/packages/llmix/rust/tests/unit_config_registry.rs
@@ -305,12 +305,16 @@ fn signed_registry_root_refresh_fails_closed_when_trust_anchor_stays_pinned() {
     let error = manager
         .available_presets()
         .expect_err("signed refresh should fail closed when pinned digest changes");
+    assert!(matches!(error, LlmixError::Security(_)));
     assert!(
         error.to_string().contains("expected_root_digest"),
         "unexpected error: {error}"
     );
     assert_eq!(manager.active_revision(), "signed-1");
-    assert!(manager.last_reload_error().is_some());
+    assert!(matches!(
+        manager.last_reload_error(),
+        Some(LlmixError::Security(_))
+    ));
 }
 
 #[test]

--- a/packages/llmix/rust/tests/unit_config_registry.rs
+++ b/packages/llmix/rust/tests/unit_config_registry.rs
@@ -207,9 +207,7 @@ fn publish_creates_active_revision_and_manager_reads_canonical_resolved_json() {
     assert_eq!(manager.current_path(), root.join("current.json").as_path());
     assert_eq!(manager.compiled_dir(), root.join("compiled").as_path());
     assert_eq!(
-        manager
-            .available_presets()
-            .expect("available presets should list"),
+        manager.available_presets(),
         vec!["search/summary".to_string()]
     );
     assert!(root
@@ -303,7 +301,7 @@ fn signed_registry_root_refresh_fails_closed_when_trust_anchor_stays_pinned() {
 
     assert_ne!(second.registry_root_sha256, first.registry_root_sha256);
     let error = manager
-        .available_presets()
+        .get_preset("search", "summary")
         .expect_err("signed refresh should fail closed when pinned digest changes");
     assert!(matches!(error, LlmixError::Security(_)));
     assert!(


### PR DESCRIPTION
## Summary

- align Python and Rust registry manager/publisher behavior with the TypeScript registry flow
- add idempotent revision retry handling, fail-closed signed-root refresh behavior, and stronger signed-root retry checks
- expand Python and Rust tests for retry, tamper rejection, trust-anchor, and parity paths

## Validation

- Codex Reviewer: approve / no material findings for updated Python and Rust registry files
- bun run test:python -- packages/llmix/python/tests/test_config_registry_trusted_root.py
- cargo test --manifest-path packages/llmix/rust/Cargo.toml --test unit_config_registry
- bun run check:python
- bun run check:rust
- uv run --project packages/llmix/python --extra dev ruff check packages/llmix/python/llmix/config_registry_publisher.py packages/llmix/python/tests/test_config_registry_trusted_root.py
- cargo fmt --manifest-path packages/llmix/rust/Cargo.toml -- --check
- git diff --check
