### PR TITLE
Map OpenAI function tools to AI SDK tool maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ LLMix uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+### Fixed
+
+- Convert OpenAI-style function tool arrays into AI SDK tool maps in the
+  TypeScript dispatch helpers.
+
 ## [2.0.7] — 2026-05-29
 
 ### Added

--- a/packages/llmix/typescript/src/dispatchers.ts
+++ b/packages/llmix/typescript/src/dispatchers.ts
@@ -59,6 +59,12 @@ type OpenAiCompatibleProvider = ((modelId: string) => LanguageModel) & {
 type ResponseFormatConfig =
   | { type: "text" }
   | { type: "json"; schema?: JSONValue; name?: string; description?: string };
+type OpenAiFunctionTool = {
+  type: "function";
+  function: Record<string, unknown> & {
+    name: string;
+  };
+};
 type OpenRouterMessage = {
   role: "system" | "user" | "assistant" | "tool";
   content?: unknown;
@@ -253,9 +259,38 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null && !Array.isArray(value);
 }
 
+function isOpenAiFunctionTool(value: unknown): value is OpenAiFunctionTool {
+  if (!isRecord(value) || value["type"] !== "function") {
+    return false;
+  }
+  const fn = value["function"];
+  return isRecord(fn) && typeof fn["name"] === "string" && fn["name"].length > 0;
+}
+
+function resolveOpenAiFunctionTools(tools: readonly unknown[]): ToolSet | undefined {
+  const entries = tools
+    .filter(isOpenAiFunctionTool)
+    .map((tool) => {
+      const description = typeof tool.function["description"] === "string" ? tool.function["description"] : undefined;
+      const parameters = tool.function["parameters"];
+      return [
+        tool.function.name,
+        {
+          ...(description !== undefined ? { description } : {}),
+          ...(parameters !== undefined ? { inputSchema: parameters as JSONValue } : {}),
+        },
+      ] as const;
+    });
+
+  return entries.length > 0 ? Object.fromEntries(entries) as unknown as ToolSet : undefined;
+}
+
 function resolveTools(kwargs: Record<string, unknown>): ToolSet | undefined {
   const tools = kwargs["tools"];
-  if (tools && typeof tools === "object") {
+  if (Array.isArray(tools)) {
+    return resolveOpenAiFunctionTools(tools);
+  }
+  if (isRecord(tools)) {
     return tools as ToolSet;
   }
   return undefined;

--- a/packages/llmix/typescript/tests/dispatchers.test.ts
+++ b/packages/llmix/typescript/tests/dispatchers.test.ts
@@ -146,6 +146,20 @@ const result = await dispatch({
     seed: 7,
     max_tokens: 256,
     response_format: { type: "json_object" },
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "lookup_weather",
+          description: "Look up weather.",
+          parameters: {
+            type: "object",
+            properties: { city: { type: "string" } },
+            required: ["city"],
+          },
+        },
+      },
+    ],
   },
   config: {
     provider: "openai",
@@ -168,6 +182,20 @@ assertDeepEq(capturedOptions?.["stopSequences"], ["END"], "stop forwarded as sto
 assertEq(capturedOptions?.["seed"], 7, "seed forwarded");
 assertEq(capturedOptions?.["maxOutputTokens"], 256, "max_tokens forwarded as maxOutputTokens");
 assertDeepEq(capturedOptions?.["output"], { kind: "json" }, "json_object response_format forwarded via output");
+assertDeepEq(
+  capturedOptions?.["tools"],
+  {
+    lookup_weather: {
+      description: "Look up weather.",
+      inputSchema: {
+        type: "object",
+        properties: { city: { type: "string" } },
+        required: ["city"],
+      },
+    },
+  },
+  "OpenAI function tools forwarded as AI SDK tool map",
+);
 assertEq(
   requireCreateOpenAIOptions()["baseURL"],
   "https://api.openai.com/v1",


### PR DESCRIPTION
<!-- Thanks for opening a PR. Please fill the sections below. -->

## What

Maps OpenAI-style `tools: [{ type: "function", function: ... }]` arrays into the AI SDK `ToolSet` record shape before calling `generateText`.

Existing AI SDK tool maps are still forwarded unchanged. I also added a dispatcher regression test and an Unreleased changelog entry.

## Why

The TypeScript dispatch helpers accept OpenAI-compatible kwargs, and the README notes that OpenAI-compatible providers reuse the OpenAI request shape. Before this change, an OpenAI function-tool array was passed through as `tools` directly, but AI SDK v6 expects a record keyed by tool name.

That means callers using the OpenAI request shape for tool definitions could hand `generateText` the wrong tool container shape.

## How

`resolveTools` now detects arrays separately from AI SDK tool-map objects. Recognized OpenAI function tools are converted by name and keep their `description` and JSON Schema `parameters` as AI SDK `description` and `inputSchema`.

I kept this TypeScript-only because the conversion is specific to the TypeScript AI SDK dispatch path and its `ToolSet` input shape.

## Tests

- [x] `bun run build` passes
- [x] `bun run check` clean
- [ ] `bun run test` passes

Additional focused validation:

- [x] `bun run test:typescript` passes
- [x] `bun test tests/dispatchers.test.ts` passes, including `OpenAI function tools forwarded as AI SDK tool map`

I left the full test checkbox unchecked because `bun run test` fails in Rust `tests/unit_config.rs` on this macOS checkout. The same `bun run test:rust --test unit_config` failure reproduces on `origin/main` with four existing failures around config-not-found assertions and `/private/var` vs `/var` temp paths, so it does not appear related to this TypeScript dispatcher change.

## Cross-language parity

<!-- If the change touches the public contract, both Python + TypeScript (and Rust where applicable) must move together. Tick what applies. -->

- [ ] Pure docs / examples / scripts (no parity impact)
- [ ] Python only (justify why TS/Rust is unaffected)
- [x] TypeScript only (Python/Rust are unaffected because this adapts OpenAI function-tool arrays to the TypeScript AI SDK `ToolSet` shape before `generateText`)
- [ ] Rust only (justify why Py/TS is unaffected)
- [ ] All bindings updated together
