### PR TITLE
chore: upgrade llmix to AI SDK 7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ LLMix uses [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [2.1.0] — 2026-07-02
+
+### Changed
+
+- Upgraded the TypeScript dispatcher integration to AI SDK 7 and `@ai-sdk/*` 4.
+- Raised the TypeScript LLMix runtime requirement to Node.js 22 or newer.
+- Converted system-role messages to AI SDK 7 `instructions` before generation.
+- Normalized generation metadata from the final AI SDK step for model, usage,
+  and tool-call reporting.
+
 ## [2.0.7] — 2026-05-29
 
 ### Added

--- a/bun.lock
+++ b/bun.lock
@@ -5,17 +5,17 @@
     "": {
       "name": "llmix",
       "devDependencies": {
-        "@types/node": "^20.14.0",
+        "@types/node": "^24.0.0",
       },
     },
     "packages/llmix/typescript": {
       "name": "@snoai/llmix",
-      "version": "2.0.7",
+      "version": "2.1.0",
       "bin": {
         "llmix": "dist/cli.js",
       },
       "dependencies": {
-        "@ai-sdk/provider": "^3.0.10",
+        "@ai-sdk/provider": "^4.0.1",
         "@openrouter/sdk": "^0.12.21",
         "@snoai/mda-config": "^1.1.2",
         "lru-cache": "^11.3.0",
@@ -23,22 +23,22 @@
         "zod": "^4.4.3",
       },
       "devDependencies": {
-        "@ai-sdk/anthropic": "^3.0.66",
-        "@ai-sdk/google": "^3.0.0",
-        "@ai-sdk/openai": "^3.0.0",
+        "@ai-sdk/anthropic": "^4.0.5",
+        "@ai-sdk/google": "^4.0.6",
+        "@ai-sdk/openai": "^4.0.5",
         "@anthropic-ai/sdk": "^0.98.0",
         "@types/node": "^25.6.2",
         "@types/proper-lockfile": "^4.1.4",
-        "ai": "^6.0.0",
+        "ai": "^7.0.11",
         "ioredis": "^5.4.1",
         "typescript": "^6.0.3",
       },
       "peerDependencies": {
-        "@ai-sdk/anthropic": ">=3.0.0",
-        "@ai-sdk/google": ">=3.0.0",
-        "@ai-sdk/openai": ">=3.0.0",
+        "@ai-sdk/anthropic": ">=4.0.0",
+        "@ai-sdk/google": ">=4.0.0",
+        "@ai-sdk/openai": ">=4.0.0",
         "@anthropic-ai/sdk": ">=0.80.0",
-        "ai": ">=6.0.0",
+        "ai": ">=7.0.0",
         "ioredis": ">=5.0.0",
       },
       "optionalPeers": [
@@ -73,17 +73,17 @@
     },
   },
   "packages": {
-    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@3.0.75", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-5AV3CKwaOJFdGXhihVgvRLNrjwRn2Xmy71YygT8DYOA+5zTx93Seg2QSIS8b3tJxzZ7X4H84pEtrE8VZKBCZGA=="],
+    "@ai-sdk/anthropic": ["@ai-sdk/anthropic@4.0.5", "", { "dependencies": { "@ai-sdk/provider": "4.0.1", "@ai-sdk/provider-utils": "5.0.3" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-JyJYKWGYz8vfoQ1pCm48a9zgX3Gvb2/6iGHb+8pEelpqnOiUq3aDHVq+nYMf9VepqcjCuH0JSOwBrKiPg/PD9w=="],
 
-    "@ai-sdk/gateway": ["@ai-sdk/gateway@3.0.110", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-sbv8+1L9/BRKydn8dMNwoMQKupA4iLJ9N+yvxgW6wMQ/94UepDf3FeYWMj/dLdzolAHZ6izRUP4s5WqQkmJ2Zg=="],
+    "@ai-sdk/gateway": ["@ai-sdk/gateway@4.0.8", "", { "dependencies": { "@ai-sdk/provider": "4.0.1", "@ai-sdk/provider-utils": "5.0.3", "@vercel/oidc": "3.2.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-esHzojMp+LllqOnEu6sYa6NKOmPcE5UObPV61LE6L2QAzCH6WHMgTS+Q/HF5HU3lVUWsHtkDzN7TNqMfv/ecCg=="],
 
-    "@ai-sdk/google": ["@ai-sdk/google@3.0.67", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Qeq+SidYtzMrcf0fdw3L0QLmtXK+ErwdBzbxS4+0Q/2UP85Ges8RJJcbAj7SO8e2JbeJoM35BLqkeNy1o3wJvQ=="],
+    "@ai-sdk/google": ["@ai-sdk/google@4.0.6", "", { "dependencies": { "@ai-sdk/provider": "4.0.1", "@ai-sdk/provider-utils": "5.0.3" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-YJnWlHVqG6Lq3NY5Z0hs1+8+P4GFTBLPkmnuFIGdsYi19qB7C36IpK2JOzdkyE47waVJuu6tq/d0rFyHZzY2MQ=="],
 
-    "@ai-sdk/openai": ["@ai-sdk/openai@3.0.62", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-Oy74Bztik2X25wZD9HRd83BAXOKcRvrfgz9gvVGqKj68yegf447NiElPbB6TSVb8zyiY9wv1GSGywMCxnnoF9g=="],
+    "@ai-sdk/openai": ["@ai-sdk/openai@4.0.5", "", { "dependencies": { "@ai-sdk/provider": "4.0.1", "@ai-sdk/provider-utils": "5.0.3" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-a9cYQNAKAbkMTt6bHAvDuLv3klwtJT9m0A6x7s8EZlf1ebcxadg/1CONaYh1GA80ZRA9UQHJUS2wHoOphkQQkg=="],
 
-    "@ai-sdk/provider": ["@ai-sdk/provider@3.0.10", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-Q3BZ27qfpYqnCYGvE3vt+Qi6LGOF9R5Nmzn+9JoM1lCRsD9mYaIhfJLkSunN48nfGXJ6n+XNV0J/XVpqGQl7Dw=="],
+    "@ai-sdk/provider": ["@ai-sdk/provider@4.0.1", "", { "dependencies": { "json-schema": "^0.4.0" } }, "sha512-6p3C/vGqVIjcptBu1DnVd/BZJ2wWmV9TUv9192vT6ZvT9KNED8EwRTqyqFpoQZKgSbMDSvBSq3dqR524Nt/Crw=="],
 
-    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@4.0.26", "", { "dependencies": { "@ai-sdk/provider": "3.0.10", "@standard-schema/spec": "^1.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-CsKNLKsOpvPujRlIYvoz+Ybw+kGn7J4/fIZa/58+R7iWLLfwn6ifE2G6Yq8K9XvH/I/3bzaDAJ3NhRwEMsLBKQ=="],
+    "@ai-sdk/provider-utils": ["@ai-sdk/provider-utils@5.0.3", "", { "dependencies": { "@ai-sdk/provider": "4.0.1", "@standard-schema/spec": "^1.1.0", "@workflow/serde": "4.1.0", "eventsource-parser": "^3.0.8" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-El0JOXXGcHFe6+owJ1UV0VgB9XtdivP8vcZni+rUIt6lt+cBHCnUdddaA6LE2avJGJ5AD0uXSY+uAvRL2tSvgw=="],
 
     "@anthropic-ai/sdk": ["@anthropic-ai/sdk@0.98.0", "", { "dependencies": { "json-schema-to-ts": "^3.1.1", "standardwebhooks": "^1.0.0" }, "peerDependencies": { "zod": "^3.25.0 || ^4.0.0" }, "optionalPeers": ["zod"], "bin": { "anthropic-ai-sdk": "bin/cli" } }, "sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg=="],
 
@@ -183,7 +183,7 @@
 
     "@types/js-yaml": ["@types/js-yaml@4.0.9", "", {}, "sha512-k4MGaQl5TGo/iipqb2UDG2UwjXziSWkh0uysQelTlJpX1qGlpUZYm8PnO4DxG1qBomtJUdYJ6qR6xdIah10JLg=="],
 
-    "@types/node": ["@types/node@20.19.40", "", { "dependencies": { "undici-types": "~6.21.0" } }, "sha512-xxx6M2IpSTnnKcR0cMvIiohkiCx20/oRPtWGbenFygKCGl3zqUzdNjQ/1V4solq1LU+dgv0nQzeGOuqkqZGg0Q=="],
+    "@types/node": ["@types/node@24.13.2", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA=="],
 
     "@types/proper-lockfile": ["@types/proper-lockfile@4.1.4", "", { "dependencies": { "@types/retry": "*" } }, "sha512-uo2ABllncSqg9F1D4nugVl9v93RmjxF6LJzQLMLDdPaXCUIDPeOJ21Gbqi43xNKzBi/WQ0Q0dICqufzQbMjipQ=="],
 
@@ -205,9 +205,11 @@
 
     "@vitest/utils": ["@vitest/utils@4.1.7", "", { "dependencies": { "@vitest/pretty-format": "4.1.7", "convert-source-map": "^2.0.0", "tinyrainbow": "^3.1.0" } }, "sha512-T532WBu791cBxJlCl6SO+J14l81DQx6uQHm1bQbmCDY7nqlEIgkza/UFnSBNaUtSf41unldDFjdOBYEQC4b5Hw=="],
 
+    "@workflow/serde": ["@workflow/serde@4.1.0", "", {}, "sha512-pav4F2BoirECWR7Nf1TKt+2eETcBj7jj4cBefQ8VXQCA6NPkaKeLfj/zMgi+3zYV5ZIBT4GuUiphsj0/b9hPQQ=="],
+
     "agent-base": ["agent-base@7.1.4", "", {}, "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ=="],
 
-    "ai": ["ai@6.0.175", "", { "dependencies": { "@ai-sdk/gateway": "3.0.110", "@ai-sdk/provider": "3.0.10", "@ai-sdk/provider-utils": "4.0.26", "@opentelemetry/api": "1.9.0" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-6fFFHzbh6FIZnYc31V6osOxq25ABJYCShfG0O6ajHiA4FB/DgnPi1mP8cO5aAU3HNSbQHiMazdlh9bIsp97mVA=="],
+    "ai": ["ai@7.0.11", "", { "dependencies": { "@ai-sdk/gateway": "4.0.8", "@ai-sdk/provider": "4.0.1", "@ai-sdk/provider-utils": "5.0.3" }, "peerDependencies": { "zod": "^3.25.76 || ^4.1.8" } }, "sha512-ecCtume1NKJG/8oIkV8G26KL9jmFJRx6+Gjx2260FcDZqIUGPiF1uBoNeGy4S1vxbHmFxUul4D7axqiXZZ1XuA=="],
 
     "ajv": ["ajv@8.20.0", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA=="],
 
@@ -407,7 +409,7 @@
 
     "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
 
-    "undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "vite": ["vite@8.0.14", "", { "dependencies": { "lightningcss": "^1.32.0", "picomatch": "^4.0.4", "postcss": "^8.5.15", "rolldown": "1.0.2", "tinyglobby": "^0.2.16" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.1.18", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-s4BJJ+5y1pYL6Otw51FHhVJQhPnuRinKig64g/1+EUNaJsd3gCKdD31IPFvswUgW9/60QT9oFHbZHbQK5imcxw=="],
 
@@ -419,7 +421,7 @@
 
     "zod": ["zod@4.4.3", "", {}, "sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ=="],
 
-    "@snoai/llmix/@types/node": ["@types/node@25.6.2", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-sokuT28dxf9JT5Kady1fsXOvI4HVpjZa95NKT5y9PNTIrs2AsobR4GFAA90ZG8M+nxVRLysCXsVj6eGC7Vbrlw=="],
+    "@snoai/llmix/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
     "@snoai/mda-config/@types/node": ["@types/node@25.9.1", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg=="],
 
@@ -429,7 +431,7 @@
 
     "minipass-pipeline/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
 
-    "@snoai/llmix/@types/node/undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
+    "@snoai/llmix/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
 
     "@snoai/mda-config/@types/node/undici-types": ["undici-types@7.24.6", "", {}, "sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg=="],
   }

--- a/package.json
+++ b/package.json
@@ -29,6 +29,6 @@
     "clean": "bun run --cwd packages/llmix/typescript clean && rm -rf packages/mda-config/typescript/dist"
   },
   "devDependencies": {
-    "@types/node": "^20.14.0"
+    "@types/node": "^24.0.0"
   }
 }

--- a/packages/llmix/python/llmix/__init__.py
+++ b/packages/llmix/python/llmix/__init__.py
@@ -6,7 +6,7 @@ Config-driven LLM configuration utilities for Python.
 
 from typing import TYPE_CHECKING
 
-__version__ = "2.0.7"
+__version__ = "2.1.0"
 
 # Pricing is always available (no external deps beyond stdlib + json)
 from llmix.pricing import MODEL_PRICING, CostBreakdown, ModelPricing, calculate_cost, calculate_rerank_cost, get_model_pricing, normalize_model_name

--- a/packages/llmix/python/pyproject.toml
+++ b/packages/llmix/python/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "sno-llmix"
-version = "2.0.7"
+version = "2.1.0"
 description = "Cross-runtime LLM orchestration for Python, TypeScript, and Rust with L2 caching, retries, key rotation, and config-driven runtime control"
 readme = "README.md"
 requires-python = ">=3.14"

--- a/packages/llmix/rust/Cargo.lock
+++ b/packages/llmix/rust/Cargo.lock
@@ -560,7 +560,7 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "llmix-rs"
-version = "2.0.7"
+version = "2.1.0"
 dependencies = [
  "async-trait",
  "chrono",

--- a/packages/llmix/rust/Cargo.toml
+++ b/packages/llmix/rust/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "llmix-rs"
-version = "2.0.7"
+version = "2.1.0"
 edition = "2021"
 rust-version = "1.83"
 license = "Apache-2.0"

--- a/packages/llmix/typescript/package.json
+++ b/packages/llmix/typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@snoai/llmix",
-  "version": "2.0.7",
+  "version": "2.1.0",
   "description": "Config-driven harness around your LLM SDK. MDA-driven model swap, two-tier cache, circuit breaker, key-pool rotation.",
   "author": "Sno AI",
   "license": "Apache-2.0",
@@ -18,7 +18,7 @@
   },
   "type": "module",
   "engines": {
-    "node": ">=20"
+    "node": ">=22"
   },
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",
@@ -50,7 +50,7 @@
     "prepublishOnly": "bun run clean && bun run build"
   },
   "dependencies": {
-    "@ai-sdk/provider": "^3.0.10",
+    "@ai-sdk/provider": "^4.0.1",
     "@snoai/mda-config": "^1.1.2",
     "@openrouter/sdk": "^0.12.21",
     "lru-cache": "^11.3.0",
@@ -58,11 +58,11 @@
     "zod": "^4.4.3"
   },
   "peerDependencies": {
-    "@ai-sdk/anthropic": ">=3.0.0",
-    "@ai-sdk/google": ">=3.0.0",
-    "@ai-sdk/openai": ">=3.0.0",
+    "@ai-sdk/anthropic": ">=4.0.0",
+    "@ai-sdk/google": ">=4.0.0",
+    "@ai-sdk/openai": ">=4.0.0",
     "@anthropic-ai/sdk": ">=0.80.0",
-    "ai": ">=6.0.0",
+    "ai": ">=7.0.0",
     "ioredis": ">=5.0.0"
   },
   "peerDependenciesMeta": {
@@ -86,13 +86,13 @@
     }
   },
   "devDependencies": {
-    "@ai-sdk/anthropic": "^3.0.66",
-    "@ai-sdk/google": "^3.0.0",
-    "@ai-sdk/openai": "^3.0.0",
+    "@ai-sdk/anthropic": "^4.0.5",
+    "@ai-sdk/google": "^4.0.6",
+    "@ai-sdk/openai": "^4.0.5",
     "@anthropic-ai/sdk": "^0.98.0",
     "@types/node": "^25.6.2",
     "@types/proper-lockfile": "^4.1.4",
-    "ai": "^6.0.0",
+    "ai": "^7.0.11",
     "ioredis": "^5.4.1",
     "typescript": "^6.0.3"
   },

--- a/packages/llmix/typescript/src/config-registry-common.ts
+++ b/packages/llmix/typescript/src/config-registry-common.ts
@@ -44,6 +44,9 @@ function sortJsonValue(value: JsonValue | JsonObject): JsonValue | JsonObject {
 
 	const sorted: JsonObject = {}
 	for (const [key, item] of Object.entries(value).sort(([left], [right]) => left.localeCompare(right))) {
+		if (item === undefined) {
+			continue
+		}
 		sorted[key] = sortJsonValue(item)
 	}
 	return sorted

--- a/packages/llmix/typescript/src/config-registry-types.ts
+++ b/packages/llmix/typescript/src/config-registry-types.ts
@@ -17,7 +17,7 @@ export const SHA256_PATTERN = /^[a-f0-9]{64}$/
 export type ConfigRegistryJsonValue = null | boolean | number | string | ConfigRegistryJsonValue[] | ConfigRegistryJsonObject
 
 export interface ConfigRegistryJsonObject {
-	[key: string]: ConfigRegistryJsonValue
+	[key: string]: ConfigRegistryJsonValue | undefined
 }
 
 export type JsonValue = ConfigRegistryJsonValue

--- a/packages/llmix/typescript/src/dispatchers.ts
+++ b/packages/llmix/typescript/src/dispatchers.ts
@@ -1,4 +1,4 @@
-import type { JSONValue, SharedV3ProviderOptions as AiProviderOptions } from "@ai-sdk/provider";
+import type { JSONValue, SharedV4ProviderOptions as AiProviderOptions } from "@ai-sdk/provider";
 import type { LanguageModel, ModelMessage, ToolSet } from "ai";
 import {
   getAnthropicApiKey,
@@ -83,6 +83,10 @@ type OpenRouterChatResult = {
   }>;
   model?: string;
   usage?: unknown;
+};
+type GenerationMessages = {
+  messages: ModelMessage[];
+  instructions?: string;
 };
 
 function requireApiKey(
@@ -294,6 +298,31 @@ function extractUsage(usage: unknown): LLMUsage {
       ? inputTokenDetails["cacheReadTokens"]
       : undefined;
   return { inputTokens, outputTokens, totalTokens, cachedInputTokens };
+}
+
+function splitGenerationMessages(messages: ModelMessage[]): GenerationMessages {
+  const nextMessages: ModelMessage[] = [];
+  const instructions: string[] = [];
+
+  for (const message of messages) {
+    if (isRecord(message) && message["role"] === "system") {
+      const content = message["content"];
+      if (typeof content !== "string") {
+        throw new Error("AI SDK v7 requires system messages to use string content for LLMix instructions");
+      }
+      instructions.push(content);
+      continue;
+    }
+    nextMessages.push(message);
+  }
+
+  if (instructions.length === 0) {
+    return { messages: nextMessages };
+  }
+  return {
+    messages: nextMessages,
+    instructions: instructions.join("\n\n"),
+  };
 }
 
 function normalizeResult(
@@ -714,7 +743,7 @@ async function generateWithModel(
   providerOptions?: AiProviderOptions,
 ): Promise<ProviderResult> {
   const { generateText, Output } = await getAi();
-  const messages = ctx.messages as ModelMessage[];
+  const { messages, instructions } = splitGenerationMessages(ctx.messages as ModelMessage[]);
   const temperature = typeof ctx.kwargs["temperature"] === "number" ? ctx.kwargs["temperature"] : undefined;
   const seed = typeof ctx.kwargs["seed"] === "number" ? ctx.kwargs["seed"] : undefined;
   const maxOutputTokens = resolveMaxOutputTokens(ctx.kwargs);
@@ -746,6 +775,7 @@ async function generateWithModel(
 
   const result = await generateText({
     model,
+    ...(instructions !== undefined ? { instructions } : {}),
     messages,
     ...(temperature !== undefined ? { temperature } : {}),
     ...(topP !== undefined ? { topP } : {}),
@@ -759,7 +789,12 @@ async function generateWithModel(
     ...(tools ? { tools } : {}),
     ...(providerOptions ? { providerOptions } : {}),
   });
-  return normalizeResult(result.text, result.response.modelId ?? ctx.model, result.usage, result.toolCalls as unknown[] | undefined);
+  return normalizeResult(
+    result.text,
+    result.finalStep.response.modelId ?? ctx.model,
+    result.finalStep.usage,
+    result.finalStep.toolCalls as unknown[] | undefined,
+  );
 }
 
 export function openaiDispatch(): ProviderDispatchFn {
@@ -792,8 +827,8 @@ export function anthropicDispatch(): ProviderDispatchFn {
 
 export function geminiDispatch(): ProviderDispatchFn {
   return async (ctx) => {
-    const { createGoogleGenerativeAI } = await getGoogleSdk();
-    const google = createGoogleGenerativeAI({
+    const { createGoogle } = await getGoogleSdk();
+    const google = createGoogle({
       apiKey: requireApiKey(ctx.apiKey, getGeminiApiKey(), "GEMINI_API_KEY", "google"),
       baseURL: resolveBaseUrl(ctx, GOOGLE_BASE_URL),
     });

--- a/packages/llmix/typescript/src/http2.ts
+++ b/packages/llmix/typescript/src/http2.ts
@@ -6,7 +6,7 @@
  * Investigation results (Tasks 42-44):
  *
  * OpenAI (Task 42-43):
- *   AI SDK v6 doesn't directly expose HTTP transport configuration.
+ *   AI SDK doesn't directly expose an HTTP/2 transport toggle.
  *   To use HTTP/2 with OpenAI in Node.js, options are:
  *   1. Use the `openai` SDK directly with a custom `fetch` that uses undici HTTP/2
  *   2. Override the `fetch` option on the AI SDK provider
@@ -78,7 +78,7 @@ export function getProviderTransport(provider: string): ProviderTransportConfig 
  * The Python side uses httpx.AsyncClient(http2=True) which works today.
  */
 export function createOpenAITransport(): undefined {
-  // TODO: Implement once AI SDK v6 exposes transport hooks or we adopt undici.
+  // TODO: Implement once AI SDK exposes an HTTP/2 transport hook or we adopt undici.
   // See investigation notes in module docstring.
   return undefined;
 }

--- a/packages/llmix/typescript/src/mda-loader.ts
+++ b/packages/llmix/typescript/src/mda-loader.ts
@@ -275,7 +275,7 @@ export async function verifyPathContainmentAsync(
 // =============================================================================
 
 /**
- * Common AI SDK v6 parameters schema
+ * Common AI SDK v7 parameters schema
  */
 export const CommonParamsSchema = z
   .object({

--- a/packages/llmix/typescript/src/types.ts
+++ b/packages/llmix/typescript/src/types.ts
@@ -2,7 +2,7 @@
  * LLMix Types
  *
  * Type definitions for the LLM Config Loader package.
- * Schema mirrors AI SDK v6 exactly - no parameter renaming required.
+ * Schema mirrors AI SDK v7 generation options where LLMix passes values through.
  *
  * @see https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-text
  */
@@ -114,7 +114,7 @@ export interface TimeoutConfig {
 }
 
 // =============================================================================
-// LLM CONFIG SCHEMA - AI SDK V6 ALIGNED
+// LLM CONFIG SCHEMA - AI SDK V7 ALIGNED
 // =============================================================================
 
 /**
@@ -135,7 +135,7 @@ export type Provider =
 export type ProviderOrUnknown = Provider | "unknown";
 
 /**
- * Common AI SDK v6 parameters
+ * Common AI SDK v7 parameters
  *
  * These map directly to generateText/streamText params.
  * @see https://ai-sdk.dev/docs/reference/ai-sdk-core/generate-text
@@ -180,7 +180,7 @@ export interface CommonParams {
 }
 
 // =============================================================================
-// PROVIDER-SPECIFIC OPTIONS - AI SDK V6 ALIGNED
+// PROVIDER-SPECIFIC OPTIONS - AI SDK V7 ALIGNED
 // =============================================================================
 
 /**
@@ -383,7 +383,7 @@ export interface SnoGpuProviderOptions {
 /**
  * Union type for all provider options
  *
- * Keys match AI SDK v6 providerOptions structure.
+ * Keys match AI SDK v7 providerOptions structure.
  */
 export interface ProviderOptions {
   openai?: OpenAIProviderOptions | undefined;
@@ -400,8 +400,8 @@ export interface ProviderOptions {
 /**
  * Full LLM configuration schema
  *
- * This schema mirrors AI SDK v6 exactly - values are passed directly
- * to generateText/streamText without translation.
+ * This schema mirrors AI SDK v7 generation options where values are passed directly
+ * to generateText/streamText.
  */
 export interface LLMConfig {
   /** LLM provider (required) */
@@ -410,7 +410,7 @@ export interface LLMConfig {
   /** Provider-specific model ID (required) */
   model: string;
 
-  /** Common AI SDK v6 parameters */
+  /** Common AI SDK v7 parameters */
   common?: CommonParams | undefined;
 
   /** Provider-specific options */

--- a/packages/llmix/typescript/tests/dispatchers.test.ts
+++ b/packages/llmix/typescript/tests/dispatchers.test.ts
@@ -63,9 +63,16 @@ mock.module("ai", () => ({
     capturedOptions = options;
     return {
       text: "ok",
-      response: { modelId: "gpt-4o-mini" },
-      usage: { inputTokens: 1, outputTokens: 2, totalTokens: 3 },
-      toolCalls: [],
+      finalStep: {
+        response: { modelId: "gpt-4o-mini" },
+        usage: {
+          inputTokens: 1,
+          outputTokens: 2,
+          totalTokens: 3,
+          inputTokenDetails: { cacheReadTokens: 1 },
+        },
+        toolCalls: [],
+      },
     };
   },
 }));
@@ -135,7 +142,10 @@ const result = await dispatch({
   provider: "openai",
   model: "gpt-4o-mini",
   apiKey: "runtime-key",
-  messages: [{ role: "user", content: "Say hello." }],
+  messages: [
+    { role: "system", content: "Be concise." },
+    { role: "user", content: "Say hello." },
+  ],
   kwargs: {
     temperature: 0.2,
     top_p: 0.9,
@@ -154,6 +164,18 @@ const result = await dispatch({
 });
 
 assertEq(result.content, "ok", "openai dispatch returns normalized content");
+assertEq(result.model, "gpt-4o-mini", "openai dispatch returns final step model");
+assertDeepEq(
+  result.usage,
+  { inputTokens: 1, outputTokens: 2, totalTokens: 3, cachedInputTokens: 1 },
+  "openai dispatch returns final step usage",
+);
+assertEq(capturedOptions?.["instructions"], "Be concise.", "system message forwarded as instructions");
+assertDeepEq(
+  capturedOptions?.["messages"],
+  [{ role: "user", content: "Say hello." }],
+  "system message removed from AI SDK messages",
+);
 assertEq(
   (capturedOptions?.["model"] as { provider?: string } | undefined)?.provider,
   "openai-responses",

--- a/uv.lock
+++ b/uv.lock
@@ -1018,7 +1018,7 @@ wheels = [
 
 [[package]]
 name = "sno-llmix"
-version = "2.0.7"
+version = "2.1.0"
 source = { editable = "packages/llmix/python" }
 dependencies = [
     { name = "anthropic" },


### PR DESCRIPTION
## Summary
- upgrade @snoai/llmix TypeScript integration to AI SDK 7 / @ai-sdk provider 4 and require Node.js >=22
- migrate system-role generation messages to AI SDK 7 instructions and read final-step model/usage/tool calls
- bump LLMix package family versions to 2.1.0 and add the release changelog entry
- fix exported config registry JSON object declarations so strict tarball consumers can typecheck the package

## Verification
- bun run --cwd packages/llmix/typescript test
- bun run check
- bun run build
- npm pack --dry-run --json
- tarball install smoke test: ESM import + TypeScript consumer compile with Node types
- uv run --project packages/llmix/python --extra dev pytest -c packages/llmix/python/pyproject.toml packages/llmix/python/tests/integration
- uv run --project packages/llmix/python --extra dev pytest -c packages/llmix/python/pyproject.toml packages/llmix/python/tests/test_*.py
- cargo test --manifest-path packages/mda-config/rust/Cargo.toml
- cargo test --manifest-path packages/llmix/rust/Cargo.toml

## Notes
- The first full `bun run test` was intentionally interrupted after the LLMix Python segment exceeded the initial runtime estimate; the same test groups were rerun separately with explicit progress monitoring and passed.