### PR TITLE
chore(deps): ignore incompatible major updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,6 +6,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 10
     labels: ["dependencies", "typescript"]
+    ignore:
+      - dependency-name: "js-yaml"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "pip"
     directory: "/packages/llmix/python"
@@ -27,6 +30,9 @@ updates:
       interval: "weekly"
     open-pull-requests-limit: 5
     labels: ["dependencies", "rust"]
+    ignore:
+      - dependency-name: "lru"
+        update-types: ["version-update:semver-major"]
 
   - package-ecosystem: "cargo"
     directory: "/packages/mda-config/rust"


### PR DESCRIPTION
## Summary
- stop Dependabot from reopening the js-yaml 5 update that breaks parser tests
- stop Dependabot from reopening the lru 0.18 update that breaks the Rust 1.83 minimum

## Verification
- parsed .github/dependabot.yml with Bun YAML parser